### PR TITLE
feat: render author avatar in AuthorProfile with initials fallback

### DIFF
--- a/components.json
+++ b/components.json
@@ -21,5 +21,7 @@
   },
   "menuColor": "default",
   "menuAccent": "subtle",
-  "registries": {}
+  "registries": {
+    "@efferd": "https://efferd.com/r/{style}/{name}.json"
+  }
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,8 +1,15 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  /* config options here */
   reactCompiler: true,
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: '**',
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/components/modules/authors/ui/AuthorProfile.tsx
+++ b/src/components/modules/authors/ui/AuthorProfile.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image';
 import type { Author } from '@/@types/author';
 
 interface AuthorProfileProps {
@@ -5,9 +6,28 @@ interface AuthorProfileProps {
 }
 
 export function AuthorProfile({ author }: AuthorProfileProps) {
+  const initials = author.name
+    .split(' ')
+    .map((n) => n[0])
+    .slice(0, 2)
+    .join('')
+    .toUpperCase();
+
   return (
     <section className="flex flex-col gap-4 border-b border-zinc-200 pb-10 dark:border-zinc-800">
-      <div className="h-20 w-20 rounded-full bg-zinc-200 dark:bg-zinc-800" />
+      {author.avatarUrl ? (
+        <Image
+          src={author.avatarUrl}
+          alt={`Photo of ${author.name}`}
+          width={80}
+          height={80}
+          className="rounded-full object-cover"
+        />
+      ) : (
+        <div className="flex h-20 w-20 items-center justify-center rounded-full bg-zinc-200 text-lg font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
+          {initials}
+        </div>
+      )}
       <div>
         <h1 className="text-3xl font-semibold tracking-tight text-zinc-950 dark:text-zinc-50">
           {author.name}


### PR DESCRIPTION
Closes #5

---

## Summary

Resolves issue #5 — render author avatar image in the `AuthorProfile` component.

## Changes

- **`AuthorProfile.tsx`**: Renders a `next/image` when `author.avatarUrl` is set; falls back to a circular div showing the author's initials when it is not.
- **`next.config.ts`**: Added `images.remotePatterns` with a wildcard HTTPS pattern to allow external avatar URLs (e.g. Supabase Storage).
- **`components.json`**: Registered the Efferd UI registry (`@efferd`) as required by the issue setup instructions.

## Acceptance criteria

- [x] Authors with a populated `avatarUrl` display their profile image
- [x] Authors without an avatar display initials fallback
- [x] Avatar is circular (`rounded-full`) and does not distort (`object-cover`)
- [x] No broken image icons for any author
- [x] Passes `npx tsc --noEmit` with no type errors
- [x] Passes `next build` (lint + TypeScript + static generation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended component registry integration enabling access to external component sources
  * Enabled remote HTTPS image loading capabilities for dynamic media content support
  * Improved author profile display featuring dynamic avatar images with automatically generated initials-based fallback when avatar data is unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->