### PR TITLE
feat: editorial workflow with roles, review queue and scheduled publishing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,9 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=<your-anon-key>
 # NEVER expose this to the browser.
 SUPABASE_SERVICE_ROLE_KEY=<your-service-role-key>
 
+# Scheduled publishing cron (Vercel Cron sends it as a Bearer token)
+CRON_SECRET=<random 32+ char string>
+
 # Stellar Network Integration (ecosystem metrics + activity scanner + embeds)
 # Which network article references resolve against: testnet | mainnet (public).
 NEXT_PUBLIC_STELLAR_NETWORK=testnet

--- a/src/@types/editorial.ts
+++ b/src/@types/editorial.ts
@@ -1,0 +1,84 @@
+/**
+ * Editorial workflow types.
+ *
+ * Convention: every type in the `editorial` domain lives here.
+ * These mirror the enums and tables created in
+ * `supabase/migrations/0006_editorial_workflow.sql`.
+ */
+
+export type EditorialRole = 'owner' | 'editor' | 'author' | 'contributor';
+
+export type ReviewState = 'requested' | 'approved' | 'changes_requested';
+
+/** An authenticated admin, enriched with their editorial role. */
+export interface AdminSession {
+  id: string;
+  email: string;
+  role: EditorialRole;
+  /** `authors.id` this admin writes as, when linked. */
+  authorId: string | null;
+  displayName: string | null;
+}
+
+/** One row of the team roster on `/admin/team`. */
+export interface TeamMember {
+  email: string;
+  role: EditorialRole;
+  authorId: string | null;
+  authorName: string | null;
+  displayName: string | null;
+  createdAt: string;
+}
+
+/**
+ * One append-only event in an article's review thread.
+ *
+ * `requestedBy` is the actor who appended the event, whatever its state:
+ * the author on a `requested` row, the reviewer on a resolution row.
+ */
+export interface ArticleReviewEvent {
+  id: string;
+  articleId: string;
+  versionNumber: number | null;
+  state: ReviewState;
+  requestedBy: string;
+  reviewerEmail: string | null;
+  comment: string | null;
+  createdAt: string;
+  resolvedAt: string | null;
+}
+
+/** An article whose newest review event is still `requested`. */
+export interface OpenReviewItem {
+  articleId: string;
+  articleTitle: string;
+  articleSlug: string;
+  requestedBy: string;
+  versionNumber: number | null;
+  comment: string | null;
+  requestedAt: string;
+  /** Diff of the version the review was filed against, when available. */
+  diffSummary: import('./news').ArticleVersionDiffSummary | null;
+}
+
+/** An article occupying a slot on the editorial calendar. */
+export interface CalendarEntry {
+  articleId: string;
+  title: string;
+  slug: string;
+  status: 'scheduled' | 'published';
+  /** `scheduled_at` for scheduled entries, `published_at` for published ones. */
+  date: string;
+  authorName: string | null;
+}
+
+export interface EditorialAuditEntry {
+  id: string;
+  actorEmail: string;
+  action: string;
+  entity: string;
+  entityId: string | null;
+  fromStatus: string | null;
+  toStatus: string | null;
+  createdAt: string;
+}

--- a/src/@types/news.ts
+++ b/src/@types/news.ts
@@ -8,7 +8,12 @@
 
 export type NewsCategory = 'announcement' | 'product' | 'ecosystem' | 'engineering' | 'community';
 
-export type NewsStatus = 'draft' | 'published' | 'archived';
+/**
+ * Mirrors the `news_status` enum. `in_review` and `scheduled` were added by
+ * the editorial workflow (`0006_editorial_workflow.sql`); neither is ever
+ * visible to anonymous readers, which still only see `published`.
+ */
+export type NewsStatus = 'draft' | 'in_review' | 'scheduled' | 'published' | 'archived';
 
 export interface NewsAuthor {
   id: string;

--- a/src/app/admin/(protected)/calendar/page.tsx
+++ b/src/app/admin/(protected)/calendar/page.tsx
@@ -1,0 +1,10 @@
+import { AdminCalendarPageContent } from '@/components/modules/admin/pages/AdminCalendarPage';
+
+interface AdminCalendarPageProps {
+  searchParams: Promise<{ month?: string }>;
+}
+
+export default async function AdminCalendarPage({ searchParams }: AdminCalendarPageProps) {
+  const { month } = await searchParams;
+  return <AdminCalendarPageContent month={month} />;
+}

--- a/src/app/admin/(protected)/layout.tsx
+++ b/src/app/admin/(protected)/layout.tsx
@@ -5,7 +5,12 @@ export default async function AdminLayout({ children }: { children: React.ReactN
   const admin = await requireAdmin();
 
   return (
-    <AdminShell email={admin.email} title="Editorial panel" subtitle="Manage news and publications">
+    <AdminShell
+      email={admin.email}
+      role={admin.role}
+      title="Editorial panel"
+      subtitle="Manage news and publications"
+    >
       {children}
     </AdminShell>
   );

--- a/src/app/admin/(protected)/monthly-reviews/[id]/edit/page.tsx
+++ b/src/app/admin/(protected)/monthly-reviews/[id]/edit/page.tsx
@@ -36,6 +36,7 @@ export default async function AdminEditMonthlyReviewPage({
   return (
     <AdminShell
       email={admin.email}
+      role={admin.role}
       title="Edit Review"
       subtitle={`Editing monthly review for ${review.period}`}
     >

--- a/src/app/admin/(protected)/monthly-reviews/new/page.tsx
+++ b/src/app/admin/(protected)/monthly-reviews/new/page.tsx
@@ -17,6 +17,7 @@ export default async function AdminNewMonthlyReviewPage() {
   return (
     <AdminShell
       email={admin.email}
+      role={admin.role}
       title="Create Review"
       subtitle="Create a new monthly ecosystem review."
     >

--- a/src/app/admin/(protected)/monthly-reviews/page.tsx
+++ b/src/app/admin/(protected)/monthly-reviews/page.tsx
@@ -13,6 +13,7 @@ export default async function AdminMonthlyReviewsPage() {
   return (
     <AdminShell
       email={admin.email}
+      role={admin.role}
       title="Monthly Reviews"
       subtitle="Manage and publish monthly ACTA reviews."
     >

--- a/src/app/admin/(protected)/news/page.tsx
+++ b/src/app/admin/(protected)/news/page.tsx
@@ -1,7 +1,10 @@
-import { AdminNewsPageContent } from '@/components/modules/admin/pages/AdminNewsPage';
+import {
+  AdminNewsPageContent,
+  type AdminNewsFilterStatus,
+} from '@/components/modules/admin/pages/AdminNewsPage';
 
 interface AdminNewsPageProps {
-  searchParams: Promise<{ status?: 'all' | 'draft' | 'published' | 'archived' }>;
+  searchParams: Promise<{ status?: AdminNewsFilterStatus }>;
 }
 
 export default async function AdminNewsPage({ searchParams }: AdminNewsPageProps) {

--- a/src/app/admin/(protected)/reviews/page.tsx
+++ b/src/app/admin/(protected)/reviews/page.tsx
@@ -1,0 +1,5 @@
+import { AdminReviewQueuePageContent } from '@/components/modules/admin/pages/AdminReviewQueuePage';
+
+export default async function AdminReviewsPage() {
+  return <AdminReviewQueuePageContent />;
+}

--- a/src/app/admin/(protected)/team/page.tsx
+++ b/src/app/admin/(protected)/team/page.tsx
@@ -1,0 +1,5 @@
+import { AdminTeamPageContent } from '@/components/modules/admin/pages/AdminTeamPage';
+
+export default async function AdminTeamPage() {
+  return <AdminTeamPageContent />;
+}

--- a/src/app/api/cron/publish-scheduled/__tests__/route.test.ts
+++ b/src/app/api/cron/publish-scheduled/__tests__/route.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const publishScheduledArticles = vi.fn();
+
+vi.mock('@/components/modules/admin/services/scheduling.service', () => ({
+  publishScheduledArticles: () => publishScheduledArticles(),
+}));
+
+const { GET } = await import('../route');
+
+const ORIGINAL_SECRET = process.env.CRON_SECRET;
+
+function request(authorization?: string): Request {
+  return new Request('https://example.test/api/cron/publish-scheduled', {
+    headers: authorization ? { authorization } : {},
+  });
+}
+
+beforeEach(() => {
+  publishScheduledArticles.mockReset();
+  publishScheduledArticles.mockResolvedValue({ publishedCount: 0, published: [], errors: [] });
+  process.env.CRON_SECRET = 'test-cron-secret-value';
+});
+
+afterEach(() => {
+  if (ORIGINAL_SECRET === undefined) delete process.env.CRON_SECRET;
+  else process.env.CRON_SECRET = ORIGINAL_SECRET;
+});
+
+describe('GET /api/cron/publish-scheduled', () => {
+  it('returns 401 when the Authorization header is missing', async () => {
+    const response = await GET(request());
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: 'unauthorized' });
+    expect(publishScheduledArticles).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 for a wrong secret of the same length', async () => {
+    const response = await GET(request('Bearer test-cron-secret-WRONG'));
+
+    expect(response.status).toBe(401);
+    expect(publishScheduledArticles).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 for a secret of a different length', async () => {
+    const response = await GET(request('Bearer short'));
+
+    expect(response.status).toBe(401);
+    expect(publishScheduledArticles).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when the scheme is missing', async () => {
+    const response = await GET(request('test-cron-secret-value'));
+
+    expect(response.status).toBe(401);
+    expect(publishScheduledArticles).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when CRON_SECRET is not configured, even with a Bearer header', async () => {
+    delete process.env.CRON_SECRET;
+
+    const response = await GET(request('Bearer anything'));
+
+    expect(response.status).toBe(401);
+    expect(publishScheduledArticles).not.toHaveBeenCalled();
+  });
+
+  it('runs the job and returns its result for the correct secret', async () => {
+    publishScheduledArticles.mockResolvedValue({
+      publishedCount: 2,
+      published: [
+        { id: 'a', slug: 'one' },
+        { id: 'b', slug: 'two' },
+      ],
+      errors: [],
+    });
+
+    const response = await GET(request('Bearer test-cron-secret-value'));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ publishedCount: 2 });
+    expect(publishScheduledArticles).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 500 rather than throwing when the job fails', async () => {
+    publishScheduledArticles.mockRejectedValue(new Error('database unreachable'));
+
+    const response = await GET(request('Bearer test-cron-secret-value'));
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({ error: 'database unreachable' });
+  });
+});

--- a/src/app/api/cron/publish-scheduled/route.ts
+++ b/src/app/api/cron/publish-scheduled/route.ts
@@ -1,0 +1,46 @@
+import { timingSafeEqual } from 'node:crypto';
+import { NextResponse } from 'next/server';
+import { publishScheduledArticles } from '@/components/modules/admin/services/scheduling.service';
+
+/**
+ * Scheduled publishing endpoint.
+ *
+ * Invoked by the Vercel Cron declared in `vercel.json` (every 10 minutes),
+ * which sends `CRON_SECRET` as a Bearer token. Running here rather than in an
+ * edge function lets the job reuse the existing TypeScript services —
+ * attestation, versioning and Next.js revalidation.
+ *
+ * Overlapping runs are safe: see `publishScheduledArticles`.
+ */
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+/** Constant-time comparison so the secret cannot be recovered by timing. */
+function secretMatches(header: string | null, secret: string): boolean {
+  if (!header) return false;
+  const expected = Buffer.from(`Bearer ${secret}`);
+  const actual = Buffer.from(header);
+  if (expected.length !== actual.length) return false;
+  return timingSafeEqual(expected, actual);
+}
+
+export async function GET(request: Request) {
+  const secret = process.env.CRON_SECRET;
+  const header = request.headers.get('authorization');
+
+  if (!secret || !secretMatches(header, secret)) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const result = await publishScheduledArticles();
+    return NextResponse.json(result);
+  } catch (err) {
+    console.error('[cron] publish-scheduled failed:', err);
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : 'publish failed' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/modules/admin/actions.ts
+++ b/src/components/modules/admin/actions.ts
@@ -7,7 +7,21 @@ import { createClient } from '@/lib/supabase/server';
 import type { Json } from '@/lib/supabase';
 import { computeArticleDiff } from '@/lib/diff';
 import { submitVersionChain } from '@/lib/stellar/client';
+import {
+  canEditArticle,
+  canPublish,
+  ForbiddenError,
+  isEditorialRole,
+} from '@/lib/editorial/permissions';
+import {
+  isPublishingStatus,
+  isValidTransition,
+  type EditorialStatus,
+} from '@/lib/editorial/transitions';
 import { requireAdmin } from './services/auth.service';
+import { requireRole } from './services/roles.service';
+import { approve, requestChanges, requestReview } from './services/reviews.service';
+import { schedule, unschedule } from './services/scheduling.service';
 
 export interface AdminLoginState {
   type: 'idle' | 'success' | 'error';
@@ -80,7 +94,7 @@ function parseTags(value: FormDataEntryValue | null): string[] {
 }
 
 export async function saveAdminNewsArticleAction(formData: FormData): Promise<void> {
-  await requireAdmin();
+  const session = await requireAdmin();
 
   const supabase = await createClient();
   const id = String(formData.get('id') ?? '').trim();
@@ -90,7 +104,6 @@ export async function saveAdminNewsArticleAction(formData: FormData): Promise<vo
   const content = String(formData.get('content') ?? '').trim();
   const coverImageUrl = String(formData.get('coverImageUrl') ?? '').trim();
   const category = String(formData.get('category') ?? 'announcement');
-  const status = String(formData.get('status') ?? 'draft');
   const authorId = String(formData.get('authorId') ?? '').trim();
   const readingTimeMinutes = Number(formData.get('readingTimeMinutes') ?? 1);
   const publishedAtRaw = String(formData.get('publishedAt') ?? '').trim();
@@ -100,6 +113,9 @@ export async function saveAdminNewsArticleAction(formData: FormData): Promise<vo
     throw new Error('Required fields are missing.');
   }
 
+  // Status is deliberately absent: it only ever moves through
+  // `transitionArticleStatusAction`, so the transition guard sees every change
+  // and an ordinary save can never publish something by accident.
   const payload = {
     slug,
     title,
@@ -107,7 +123,6 @@ export async function saveAdminNewsArticleAction(formData: FormData): Promise<vo
     content,
     cover_image_url: coverImageUrl || null,
     category: category as 'announcement' | 'product' | 'ecosystem' | 'engineering' | 'community',
-    status: status as 'draft' | 'published' | 'archived',
     author_id: authorId,
     reading_time_minutes: Number.isFinite(readingTimeMinutes) ? Math.max(1, readingTimeMinutes) : 1,
     published_at: publishedAtRaw ? new Date(publishedAtRaw).toISOString() : null,
@@ -124,11 +139,22 @@ export async function saveAdminNewsArticleAction(formData: FormData): Promise<vo
     // 1. Fetch current state BEFORE the update (for diff computation)
     const { data: currentRow, error: fetchError } = await supabase
       .from('news_articles')
-      .select('title, summary, content, category, slug')
+      .select('title, summary, content, category, slug, status, author_id')
       .eq('id', articleId)
       .single();
 
     if (fetchError) throw fetchError;
+
+    if (
+      !canEditArticle(session.role, {
+        ownsArticle: session.authorId !== null && session.authorId === currentRow.author_id,
+        status: currentRow.status,
+      })
+    ) {
+      throw new ForbiddenError(
+        `role ${session.role} cannot edit this article in "${currentRow.status}"`
+      );
+    }
 
     // 2. Persist the update (this fires the DB trigger, creating the version row)
     const { error: updateError } = await supabase
@@ -191,10 +217,11 @@ export async function saveAdminNewsArticleAction(formData: FormData): Promise<vo
   } else {
     // -----------------------------------------------------------------------
     // INSERT path — first save; no prior version to diff against.
+    // Everything starts as a draft regardless of role.
     // -----------------------------------------------------------------------
     const { data, error } = await supabase
       .from('news_articles')
-      .insert(payload)
+      .insert({ ...payload, status: 'draft' })
       .select('id')
       .single();
     if (error) throw error;
@@ -222,7 +249,8 @@ export async function saveAdminNewsArticleAction(formData: FormData): Promise<vo
 }
 
 export async function deleteAdminNewsArticleAction(formData: FormData): Promise<void> {
-  await requireAdmin();
+  // Deleting is destructive and unversioned — owners only. Everyone else archives.
+  await requireRole('owner');
   const supabase = await createClient();
   const id = String(formData.get('id') ?? '').trim();
   if (!id) throw new Error('Invalid ID');
@@ -234,6 +262,230 @@ export async function deleteAdminNewsArticleAction(formData: FormData): Promise<
   revalidatePath('/admin/news');
   revalidatePath('/news');
   redirect('/admin/news');
+}
+
+// ===========================================================================
+// Editorial workflow
+//
+// Each action re-checks the role before touching the database. RLS and the
+// status-transition trigger remain the real boundary — these checks exist so a
+// blocked action fails with a readable message instead of a Postgres error.
+// ===========================================================================
+
+function revalidateArticlePaths(slug?: string | null): void {
+  revalidatePath('/admin');
+  revalidatePath('/admin/news');
+  revalidatePath('/admin/reviews');
+  revalidatePath('/admin/calendar');
+  revalidatePath('/news');
+  if (slug) revalidatePath(`/news/${slug}`);
+  revalidatePath('/');
+}
+
+async function fetchArticleForWorkflow(articleId: string) {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from('news_articles')
+    .select('id, slug, status, author_id')
+    .eq('id', articleId)
+    .single();
+
+  if (error) throw error;
+  return data;
+}
+
+/**
+ * Move an article between statuses.
+ *
+ * The database rejects an illegal move regardless; this validates first so the
+ * editor sees why, and so a stale UI cannot produce a confusing 500.
+ */
+export async function transitionArticleStatusAction(formData: FormData): Promise<void> {
+  const session = await requireAdmin();
+
+  const articleId = String(formData.get('articleId') ?? '').trim();
+  const toStatus = String(formData.get('toStatus') ?? '').trim() as EditorialStatus;
+
+  if (!articleId || !toStatus) throw new Error('Invalid transition parameters.');
+
+  const article = await fetchArticleForWorkflow(articleId);
+  const fromStatus = article.status as EditorialStatus;
+
+  if (!isValidTransition(fromStatus, toStatus)) {
+    throw new Error(`invalid status transition: ${fromStatus} -> ${toStatus}`);
+  }
+
+  if (isPublishingStatus(toStatus) && !canPublish(session.role)) {
+    throw new ForbiddenError(`role ${session.role} cannot move an article to ${toStatus}`);
+  }
+
+  const supabase = await createClient();
+  const { error } = await supabase
+    .from('news_articles')
+    .update({ status: toStatus })
+    .eq('id', articleId);
+
+  if (error) throw error;
+
+  revalidateArticlePaths(article.slug);
+  redirect(`/admin/news/${articleId}/edit`);
+}
+
+/** Queue an article for automatic publication. Owners and editors only. */
+export async function scheduleArticleAction(formData: FormData): Promise<void> {
+  await requireRole('owner', 'editor');
+
+  const articleId = String(formData.get('articleId') ?? '').trim();
+  const scheduledAtRaw = String(formData.get('scheduledAt') ?? '').trim();
+
+  if (!articleId || !scheduledAtRaw) throw new Error('Invalid schedule parameters.');
+
+  const scheduledAt = new Date(scheduledAtRaw);
+  if (Number.isNaN(scheduledAt.getTime())) throw new Error('Invalid schedule date.');
+
+  const article = await fetchArticleForWorkflow(articleId);
+  const supabase = await createClient();
+  await schedule(supabase, { articleId, scheduledAt });
+
+  revalidateArticlePaths(article.slug);
+  redirect(`/admin/news/${articleId}/edit`);
+}
+
+/**
+ * Move a scheduled article to another date.
+ *
+ * Called from the editorial calendar's drag-and-drop, so it takes plain
+ * arguments instead of FormData and refreshes via `revalidatePath` rather than
+ * redirecting — a redirect would tear down the client transition.
+ */
+export async function rescheduleArticleAction(articleId: string, isoDate: string): Promise<void> {
+  await requireRole('owner', 'editor');
+
+  if (!articleId || !isoDate) throw new Error('Invalid reschedule parameters.');
+
+  const scheduledAt = new Date(isoDate);
+  if (Number.isNaN(scheduledAt.getTime())) throw new Error('Invalid schedule date.');
+
+  const article = await fetchArticleForWorkflow(articleId);
+  if (article.status !== 'scheduled') {
+    throw new Error('Only scheduled articles can be moved on the calendar.');
+  }
+
+  const supabase = await createClient();
+  const { error } = await supabase
+    .from('news_articles')
+    .update({ scheduled_at: scheduledAt.toISOString() })
+    .eq('id', articleId);
+
+  if (error) throw error;
+
+  revalidateArticlePaths(article.slug);
+}
+
+/** Pull an article back out of the schedule, returning it to draft. */
+export async function unscheduleArticleAction(formData: FormData): Promise<void> {
+  await requireRole('owner', 'editor');
+
+  const articleId = String(formData.get('articleId') ?? '').trim();
+  if (!articleId) throw new Error('Invalid article ID.');
+
+  const article = await fetchArticleForWorkflow(articleId);
+  const supabase = await createClient();
+  await unschedule(supabase, { articleId });
+
+  revalidateArticlePaths(article.slug);
+  redirect(`/admin/news/${articleId}/edit`);
+}
+
+/** Submit an article for review. Available to every role. */
+export async function requestReviewAction(formData: FormData): Promise<void> {
+  const session = await requireAdmin();
+
+  const articleId = String(formData.get('articleId') ?? '').trim();
+  const comment = String(formData.get('comment') ?? '').trim();
+  if (!articleId) throw new Error('Invalid article ID.');
+
+  const article = await fetchArticleForWorkflow(articleId);
+
+  if (
+    !canEditArticle(session.role, {
+      ownsArticle: session.authorId !== null && session.authorId === article.author_id,
+      status: article.status as EditorialStatus,
+    })
+  ) {
+    throw new ForbiddenError(`role ${session.role} cannot submit this article for review`);
+  }
+
+  const supabase = await createClient();
+  await requestReview(supabase, { articleId, actorEmail: session.email, comment });
+
+  revalidateArticlePaths(article.slug);
+  redirect(`/admin/news/${articleId}/edit`);
+}
+
+/** Approve an open review. Owners and editors only. */
+export async function approveReviewAction(formData: FormData): Promise<void> {
+  const session = await requireRole('owner', 'editor');
+
+  const articleId = String(formData.get('articleId') ?? '').trim();
+  const comment = String(formData.get('comment') ?? '').trim();
+  if (!articleId) throw new Error('Invalid article ID.');
+
+  const supabase = await createClient();
+  await approve(supabase, { articleId, actorEmail: session.email, comment });
+
+  const article = await fetchArticleForWorkflow(articleId);
+  revalidateArticlePaths(article.slug);
+  redirect('/admin/reviews');
+}
+
+/** Send an article back to its author with a comment. Owners and editors only. */
+export async function requestChangesAction(formData: FormData): Promise<void> {
+  const session = await requireRole('owner', 'editor');
+
+  const articleId = String(formData.get('articleId') ?? '').trim();
+  const comment = String(formData.get('comment') ?? '').trim();
+  if (!articleId) throw new Error('Invalid article ID.');
+  if (!comment) throw new Error('A comment is required when requesting changes.');
+
+  const supabase = await createClient();
+  await requestChanges(supabase, { articleId, actorEmail: session.email, comment });
+
+  const article = await fetchArticleForWorkflow(articleId);
+  revalidateArticlePaths(article.slug);
+  redirect('/admin/reviews');
+}
+
+/** Change a team member's role. Owners only — enforced again by RLS. */
+export async function updateTeamMemberRoleAction(formData: FormData): Promise<void> {
+  const session = await requireRole('owner');
+
+  const email = String(formData.get('email') ?? '')
+    .trim()
+    .toLowerCase();
+  const role = String(formData.get('role') ?? '').trim();
+  const authorId = String(formData.get('authorId') ?? '').trim();
+
+  if (!email) throw new Error('Invalid email.');
+
+  // Guards against the last owner demoting themselves and locking the team
+  // page for everyone.
+  if (email === session.email) {
+    throw new ForbiddenError('You cannot change your own role — ask another owner.');
+  }
+
+  if (!isEditorialRole(role)) throw new Error(`Unknown role: ${role}`);
+
+  const supabase = await createClient();
+  const { error } = await supabase
+    .from('admin_users')
+    .update({ role, author_id: authorId || null })
+    .eq('email', email);
+
+  if (error) throw error;
+
+  revalidatePath('/admin/team');
+  redirect('/admin/team');
 }
 
 export async function saveAdminMonthlyReviewAction(formData: FormData): Promise<void> {
@@ -394,7 +646,7 @@ export async function fetchMetricsForPeriodAction(period: string, network: strin
  * which triggers the DB versioning hook and creates a new version entry.
  */
 export async function restoreArticleVersionAction(formData: FormData): Promise<void> {
-  await requireAdmin();
+  const session = await requireAdmin();
 
   const supabase = await createClient();
   const articleId = String(formData.get('articleId') ?? '').trim();
@@ -420,6 +672,15 @@ export async function restoreArticleVersionAction(formData: FormData): Promise<v
     .single();
 
   if (articleError || !article) throw new Error('Article not found.');
+
+  if (
+    !canEditArticle(session.role, {
+      ownsArticle: session.authorId !== null && session.authorId === article.author_id,
+      status: article.status,
+    })
+  ) {
+    throw new ForbiddenError(`role ${session.role} cannot restore versions of this article`);
+  }
 
   // Write the restored content as a new update (triggers versioning)
   const { error: updateError } = await supabase

--- a/src/components/modules/admin/index.ts
+++ b/src/components/modules/admin/index.ts
@@ -7,12 +7,32 @@ export { AdminNewsPageContent } from './pages/AdminNewsPage';
 export { AdminNewsEditorPageContent } from './pages/AdminNewsEditorPage';
 export { AdminMonthlyReviewsPageContent } from './pages/AdminMonthlyReviewsPage';
 export { AdminMonthlyReviewEditorPageContent } from './pages/AdminMonthlyReviewEditorPage';
+export { AdminReviewQueuePageContent } from './pages/AdminReviewQueuePage';
+export { AdminCalendarPageContent } from './pages/AdminCalendarPage';
+export { AdminTeamPageContent } from './pages/AdminTeamPage';
+
+// Editorial UI
+export { RoleBadge } from './ui/RoleBadge';
+export { StatusBadge } from './ui/StatusBadge';
+export { StatusTransitionMenu } from './ui/StatusTransitionMenu';
+export { SchedulePicker } from './ui/SchedulePicker';
+export { ReviewQueue } from './ui/ReviewQueue';
+export { ReviewCommentThread } from './ui/ReviewCommentThread';
+export { EditorialCalendar } from './ui/EditorialCalendar';
 
 // Actions
 export {
   saveAdminNewsArticleAction,
   deleteAdminNewsArticleAction,
   restoreArticleVersionAction,
+  transitionArticleStatusAction,
+  scheduleArticleAction,
+  unscheduleArticleAction,
+  rescheduleArticleAction,
+  requestReviewAction,
+  approveReviewAction,
+  requestChangesAction,
+  updateTeamMemberRoleAction,
 } from './actions';
 
 // Services
@@ -20,6 +40,14 @@ export {
   fetchAdminArticleVersions,
   fetchAdminArticleVersionByNumber,
 } from './services/versions.service';
+export { getCurrentRole, listTeam, requireRole, ForbiddenError } from './services/roles.service';
+export { listOpen, listThread } from './services/reviews.service';
+export {
+  publishScheduledArticles,
+  listCalendarEntries,
+  schedule,
+  unschedule,
+} from './services/scheduling.service';
 
 export const adminLoginMetadata = buildMetadata({
   title: 'Admin Login',

--- a/src/components/modules/admin/pages/AdminCalendarPage.tsx
+++ b/src/components/modules/admin/pages/AdminCalendarPage.tsx
@@ -1,0 +1,74 @@
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import { createClient } from '@/lib/supabase/server';
+import { canPublish } from '@/lib/editorial/permissions';
+import { requireAdmin } from '../services/auth.service';
+import { listCalendarEntries } from '../services/scheduling.service';
+import { EditorialCalendar } from '../ui/EditorialCalendar';
+
+interface AdminCalendarPageContentProps {
+  /** `YYYY-MM`; defaults to the current month. */
+  month?: string;
+}
+
+export async function AdminCalendarPageContent({ month }: AdminCalendarPageContentProps) {
+  const session = await requireAdmin();
+  const supabase = await createClient();
+
+  const active = normalizeMonth(month);
+  const from = new Date(active.year, active.monthIndex, 1);
+  const to = new Date(active.year, active.monthIndex + 1, 1);
+
+  const entries = await listCalendarEntries(supabase, { from, to });
+
+  const monthKey = `${active.year}-${pad(active.monthIndex + 1)}`;
+  const previous = shiftMonth(active, -1);
+  const next = shiftMonth(active, 1);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h2 className="text-lg font-semibold">
+          {from.toLocaleString(undefined, { month: 'long', year: 'numeric' })}
+        </h2>
+        <div className="flex gap-2">
+          <Button asChild size="sm" variant="outline">
+            <Link href={`/admin/calendar?month=${previous}`}>Previous</Link>
+          </Button>
+          <Button asChild size="sm" variant="outline">
+            <Link href="/admin/calendar">Today</Link>
+          </Button>
+          <Button asChild size="sm" variant="outline">
+            <Link href={`/admin/calendar?month=${next}`}>Next</Link>
+          </Button>
+        </div>
+      </div>
+
+      <EditorialCalendar
+        month={monthKey}
+        entries={entries}
+        canReschedule={canPublish(session.role)}
+      />
+    </div>
+  );
+}
+
+function normalizeMonth(month: string | undefined): { year: number; monthIndex: number } {
+  const now = new Date();
+  if (!month) return { year: now.getFullYear(), monthIndex: now.getMonth() };
+
+  const [y, m] = month.split('-').map(Number);
+  if (!Number.isFinite(y) || !Number.isFinite(m) || m < 1 || m > 12) {
+    return { year: now.getFullYear(), monthIndex: now.getMonth() };
+  }
+  return { year: y, monthIndex: m - 1 };
+}
+
+function shiftMonth(active: { year: number; monthIndex: number }, delta: number): string {
+  const date = new Date(active.year, active.monthIndex + delta, 1);
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}`;
+}
+
+function pad(value: number): string {
+  return String(value).padStart(2, '0');
+}

--- a/src/components/modules/admin/pages/AdminNewsEditorPage.tsx
+++ b/src/components/modules/admin/pages/AdminNewsEditorPage.tsx
@@ -4,9 +4,15 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { createClient } from '@/lib/supabase/server';
+import { canEditArticle, canPublish, canReview } from '@/lib/editorial/permissions';
 import { fetchAdminNewsById, fetchAdminNewsFormOptions } from '../services/news.service';
 import { StellarReferenceField } from '../ui/StellarReferenceField';
 import { fetchAdminArticleVersions } from '../services/versions.service';
+import { requireAdmin } from '../services/auth.service';
+import { listThread } from '../services/reviews.service';
+import { StatusTransitionMenu } from '../ui/StatusTransitionMenu';
+import { SchedulePicker } from '../ui/SchedulePicker';
+import { ReviewCommentThread } from '../ui/ReviewCommentThread';
 import { VersionHistorySidebar } from '@/components/modules/news/ui/VersionHistorySidebar';
 
 interface AdminNewsEditorPageContentProps {
@@ -14,6 +20,7 @@ interface AdminNewsEditorPageContentProps {
 }
 
 export async function AdminNewsEditorPageContent({ articleId }: AdminNewsEditorPageContentProps) {
+  const session = await requireAdmin();
   const supabase = await createClient();
   const options = await fetchAdminNewsFormOptions(supabase);
   const article = articleId ? await fetchAdminNewsById(supabase, articleId) : null;
@@ -24,6 +31,13 @@ export async function AdminNewsEditorPageContent({ articleId }: AdminNewsEditorP
 
   const versions = articleId ? await fetchAdminArticleVersions(supabase, articleId) : [];
   const currentVersionNumber = versions.length > 0 ? versions[0].versionNumber : 1;
+
+  const reviewEvents = articleId ? await listThread(supabase, articleId) : [];
+
+  const ownsArticle =
+    article !== null && session.authorId !== null && session.authorId === article.authorId;
+  const canEdit =
+    article === null || canEditArticle(session.role, { ownsArticle, status: article.status });
 
   return (
     <div className="grid gap-6 lg:grid-cols-[1fr_280px]">
@@ -70,20 +84,6 @@ export async function AdminNewsEditorPageContent({ articleId }: AdminNewsEditorP
               <option value="community">community</option>
             </select>
           </Field>
-          <Field label="Status">
-            <select
-              name="status"
-              defaultValue={article?.status ?? 'draft'}
-              className="h-8 w-full rounded-lg border bg-transparent px-2.5 text-sm"
-            >
-              <option value="draft">draft</option>
-              <option value="published">published</option>
-              <option value="archived">archived</option>
-            </select>
-          </Field>
-        </div>
-
-        <div className="grid gap-3 md:grid-cols-2">
           <Field label="Author">
             <select
               name="authorId"
@@ -97,6 +97,9 @@ export async function AdminNewsEditorPageContent({ articleId }: AdminNewsEditorP
               ))}
             </select>
           </Field>
+        </div>
+
+        <div className="grid gap-3 md:grid-cols-2">
           <Field label="Reading time (minutes)">
             <Input
               type="number"
@@ -106,16 +109,14 @@ export async function AdminNewsEditorPageContent({ articleId }: AdminNewsEditorP
               defaultValue={article?.readingTimeMinutes ?? 2}
             />
           </Field>
-        </div>
-
-        <div className="grid gap-3 md:grid-cols-2">
           <Field label="Cover image URL">
             <Input name="coverImageUrl" defaultValue={article?.coverImageUrl} />
           </Field>
-          <Field label="Published at">
-            <Input type="datetime-local" name="publishedAt" defaultValue={article?.publishedAt} />
-          </Field>
         </div>
+
+        <Field label="Published at">
+          <Input type="datetime-local" name="publishedAt" defaultValue={article?.publishedAt} />
+        </Field>
 
         <Field label="Tags (comma-separated slugs)">
           <Input
@@ -125,19 +126,51 @@ export async function AdminNewsEditorPageContent({ articleId }: AdminNewsEditorP
           />
         </Field>
 
-        <div className="flex justify-end">
-          <Button type="submit">{articleId ? 'Save changes' : 'Create article'}</Button>
+        <div className="flex items-center justify-end gap-3">
+          {!canEdit ? (
+            <p className="text-xs text-muted-foreground">
+              Your role cannot edit this article in “{article?.status}”.
+            </p>
+          ) : null}
+          <Button type="submit" disabled={!canEdit}>
+            {articleId ? 'Save changes' : 'Create article'}
+          </Button>
         </div>
       </form>
 
-      {/* ── Version history sidebar ── */}
-      {articleId && (
-        <VersionHistorySidebar
-          articleId={articleId}
-          versions={versions}
-          currentVersionNumber={currentVersionNumber}
-        />
-      )}
+      {/* ── Workflow sidebar ── */}
+      <div className="space-y-4">
+        {articleId && article ? (
+          <>
+            <StatusTransitionMenu
+              articleId={articleId}
+              status={article.status}
+              role={session.role}
+            />
+            <SchedulePicker
+              articleId={articleId}
+              status={article.status}
+              scheduledAt={article.scheduledAt}
+              canSchedule={canPublish(session.role)}
+            />
+            <ReviewCommentThread
+              articleId={articleId}
+              status={article.status}
+              events={reviewEvents}
+              canReview={canReview(session.role)}
+              canSubmit={canEdit}
+            />
+          </>
+        ) : null}
+
+        {articleId && (
+          <VersionHistorySidebar
+            articleId={articleId}
+            versions={versions}
+            currentVersionNumber={currentVersionNumber}
+          />
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/modules/admin/pages/AdminNewsPage.tsx
+++ b/src/components/modules/admin/pages/AdminNewsPage.tsx
@@ -2,31 +2,37 @@ import Link from 'next/link';
 import { deleteAdminNewsArticleAction } from '@/components/modules/admin/actions';
 import { Button } from '@/components/ui/button';
 import { createClient } from '@/lib/supabase/server';
+import { canDeleteArticles } from '@/lib/editorial/permissions';
+import { EDITORIAL_STATUSES, statusLabel, type EditorialStatus } from '@/lib/editorial/transitions';
 import { fetchAdminNewsList } from '../services/news.service';
+import { requireAdmin } from '../services/auth.service';
+import { StatusBadge } from '../ui/StatusBadge';
+
+export type AdminNewsFilterStatus = 'all' | EditorialStatus;
 
 interface AdminNewsPageContentProps {
-  status?: 'all' | 'draft' | 'published' | 'archived';
+  status?: AdminNewsFilterStatus;
 }
 
 export async function AdminNewsPageContent({ status = 'all' }: AdminNewsPageContentProps) {
+  const session = await requireAdmin();
   const supabase = await createClient();
   const items = await fetchAdminNewsList(supabase, status);
+
+  const canDelete = canDeleteArticles(session.role);
 
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap gap-2">
         <FilterButton href="/admin/news" active={status === 'all'} label="All" />
-        <FilterButton href="/admin/news?status=draft" active={status === 'draft'} label="Draft" />
-        <FilterButton
-          href="/admin/news?status=published"
-          active={status === 'published'}
-          label="Published"
-        />
-        <FilterButton
-          href="/admin/news?status=archived"
-          active={status === 'archived'}
-          label="Archived"
-        />
+        {EDITORIAL_STATUSES.map((value) => (
+          <FilterButton
+            key={value}
+            href={`/admin/news?status=${value}`}
+            active={status === value}
+            label={statusLabel(value)}
+          />
+        ))}
       </div>
 
       <div className="overflow-hidden rounded-2xl border bg-card">
@@ -47,7 +53,14 @@ export async function AdminNewsPageContent({ status = 'all' }: AdminNewsPageCont
                   <div className="font-medium">{item.title}</div>
                   <div className="text-xs text-muted-foreground">/{item.slug}</div>
                 </td>
-                <td className="px-4 py-3 uppercase">{item.status}</td>
+                <td className="px-4 py-3">
+                  <StatusBadge status={item.status} />
+                  {item.status === 'scheduled' && item.scheduledAt ? (
+                    <div className="mt-1 text-xs text-muted-foreground">
+                      {new Date(item.scheduledAt).toLocaleString()}
+                    </div>
+                  ) : null}
+                </td>
                 <td className="px-4 py-3">{item.authorName}</td>
                 <td className="px-4 py-3">{new Date(item.updatedAt).toLocaleString()}</td>
                 <td className="px-4 py-3">
@@ -55,12 +68,14 @@ export async function AdminNewsPageContent({ status = 'all' }: AdminNewsPageCont
                     <Button asChild size="sm" variant="outline">
                       <Link href={`/admin/news/${item.id}/edit`}>Edit</Link>
                     </Button>
-                    <form action={deleteAdminNewsArticleAction}>
-                      <input type="hidden" name="id" value={item.id} />
-                      <Button size="sm" variant="destructive" type="submit">
-                        Delete
-                      </Button>
-                    </form>
+                    {canDelete ? (
+                      <form action={deleteAdminNewsArticleAction}>
+                        <input type="hidden" name="id" value={item.id} />
+                        <Button size="sm" variant="destructive" type="submit">
+                          Delete
+                        </Button>
+                      </form>
+                    ) : null}
                   </div>
                 </td>
               </tr>

--- a/src/components/modules/admin/pages/AdminReviewQueuePage.tsx
+++ b/src/components/modules/admin/pages/AdminReviewQueuePage.tsx
@@ -1,0 +1,22 @@
+import { createClient } from '@/lib/supabase/server';
+import { canReview } from '@/lib/editorial/permissions';
+import { requireAdmin } from '../services/auth.service';
+import { listOpen } from '../services/reviews.service';
+import { ReviewQueue } from '../ui/ReviewQueue';
+
+export async function AdminReviewQueuePageContent() {
+  const session = await requireAdmin();
+  const supabase = await createClient();
+  const items = await listOpen(supabase);
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">
+        {items.length === 0
+          ? 'The queue is empty.'
+          : `${items.length} article${items.length === 1 ? '' : 's'} waiting for review.`}
+      </p>
+      <ReviewQueue items={items} canReview={canReview(session.role)} />
+    </div>
+  );
+}

--- a/src/components/modules/admin/pages/AdminTeamPage.tsx
+++ b/src/components/modules/admin/pages/AdminTeamPage.tsx
@@ -1,0 +1,113 @@
+import { updateTeamMemberRoleAction } from '@/components/modules/admin/actions';
+import { Button } from '@/components/ui/button';
+import { createClient } from '@/lib/supabase/server';
+import { EDITORIAL_ROLES } from '@/lib/editorial/permissions';
+import { listTeam, requireRole } from '../services/roles.service';
+import { fetchAdminNewsFormOptions } from '../services/news.service';
+import { RoleBadge } from '../ui/RoleBadge';
+
+/** Owner-only roster. `/admin/team` is also blocked for non-owners in proxy.ts. */
+export async function AdminTeamPageContent() {
+  const session = await requireRole('owner');
+  const supabase = await createClient();
+
+  const [team, options] = await Promise.all([listTeam(), fetchAdminNewsFormOptions(supabase)]);
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-2xl border bg-card p-4">
+        <h2 className="text-sm font-semibold">What each role can do</h2>
+        <ul className="mt-2 space-y-1 text-sm text-muted-foreground">
+          <li>
+            <strong>owner</strong> — everything, including managing this page.
+          </li>
+          <li>
+            <strong>editor</strong> — edit any article, approve reviews, publish, schedule, archive.
+          </li>
+          <li>
+            <strong>author</strong> — create and edit their own articles, submit for review.
+          </li>
+          <li>
+            <strong>contributor</strong> — create and edit their own drafts; cannot see others’
+            drafts.
+          </li>
+        </ul>
+      </div>
+
+      <div className="overflow-hidden rounded-2xl border bg-card">
+        <table className="w-full text-left text-sm">
+          <thead className="bg-muted/50 text-xs uppercase tracking-[0.14em] text-muted-foreground">
+            <tr>
+              <th className="px-4 py-3">Member</th>
+              <th className="px-4 py-3">Role</th>
+              <th className="px-4 py-3">Writes as</th>
+              <th className="px-4 py-3 text-right">Update</th>
+            </tr>
+          </thead>
+          <tbody>
+            {team.map((member) => {
+              const isSelf = member.email === session.email;
+              return (
+                <tr key={member.email} className="border-t align-middle">
+                  <td className="px-4 py-3">
+                    <div className="font-medium">{member.displayName ?? member.email}</div>
+                    {member.displayName ? (
+                      <div className="text-xs text-muted-foreground">{member.email}</div>
+                    ) : null}
+                  </td>
+                  <td className="px-4 py-3">
+                    <RoleBadge role={member.role} />
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground">{member.authorName ?? '—'}</td>
+                  <td className="px-4 py-3">
+                    <form
+                      action={updateTeamMemberRoleAction}
+                      className="flex flex-wrap justify-end gap-2"
+                    >
+                      <input type="hidden" name="email" value={member.email} />
+                      <select
+                        name="role"
+                        defaultValue={member.role}
+                        disabled={isSelf}
+                        className="h-8 rounded-lg border bg-transparent px-2.5 text-sm disabled:opacity-50"
+                      >
+                        {EDITORIAL_ROLES.map((role) => (
+                          <option key={role} value={role}>
+                            {role}
+                          </option>
+                        ))}
+                      </select>
+                      <select
+                        name="authorId"
+                        defaultValue={member.authorId ?? ''}
+                        className="h-8 rounded-lg border bg-transparent px-2.5 text-sm"
+                      >
+                        <option value="">no author</option>
+                        {options.authors.map((author) => (
+                          <option key={author.id} value={author.id}>
+                            {author.name}
+                          </option>
+                        ))}
+                      </select>
+                      <Button type="submit" size="sm" variant="outline">
+                        Save
+                      </Button>
+                    </form>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+        {team.length === 0 ? (
+          <p className="px-4 py-8 text-center text-sm text-muted-foreground">No team members.</p>
+        ) : null}
+      </div>
+
+      <p className="text-xs text-muted-foreground">
+        You cannot change your own role — ask another owner. Linking a member to an author record is
+        what makes “their own articles” resolvable for the author and contributor roles.
+      </p>
+    </div>
+  );
+}

--- a/src/components/modules/admin/services/__tests__/reviews.test.ts
+++ b/src/components/modules/admin/services/__tests__/reviews.test.ts
@@ -1,0 +1,422 @@
+import { describe, expect, it } from 'vitest';
+import type { TypedSupabaseClient } from '@/lib/supabase';
+import { approve, listOpen, listThread, requestChanges, requestReview } from '../reviews.service';
+
+/**
+ * Minimal PostgREST-shaped fake.
+ *
+ * Every builder is thenable and records what it was asked to do, so the tests
+ * can assert both the returned data and the exact rows the service tried to
+ * write — the version pinning in particular, which is what ties a review to
+ * the content it was written against.
+ */
+interface Call {
+  table: string;
+  op: 'select' | 'insert' | 'update';
+  payload?: Record<string, unknown>;
+  filters: [string, string, unknown][];
+}
+
+type Resolver = (call: Call) => { data: unknown; error: unknown | null };
+
+function createFakeClient(resolve: Resolver) {
+  const calls: Call[] = [];
+
+  function chain(call: Call) {
+    const api = {
+      eq(column: string, value: unknown) {
+        call.filters.push(['eq', column, value]);
+        return api;
+      },
+      in(column: string, value: unknown) {
+        call.filters.push(['in', column, value]);
+        return api;
+      },
+      order: () => api,
+      limit: () => api,
+      select: () => api,
+      maybeSingle: () => Promise.resolve(resolve(call)),
+      single: () => Promise.resolve(resolve(call)),
+      then: (ok: (v: unknown) => unknown, err?: (e: unknown) => unknown) =>
+        Promise.resolve(resolve(call)).then(ok, err),
+    };
+    return api;
+  }
+
+  const client = {
+    from(table: string) {
+      return {
+        select() {
+          const call: Call = { table, op: 'select', filters: [] };
+          calls.push(call);
+          return chain(call);
+        },
+        insert(payload: Record<string, unknown>) {
+          const call: Call = { table, op: 'insert', payload, filters: [] };
+          calls.push(call);
+          return chain(call);
+        },
+        update(payload: Record<string, unknown>) {
+          const call: Call = { table, op: 'update', payload, filters: [] };
+          calls.push(call);
+          return chain(call);
+        },
+      };
+    },
+  };
+
+  return {
+    client: client as unknown as TypedSupabaseClient,
+    calls,
+    inserts: () => calls.filter((c) => c.op === 'insert'),
+    updates: () => calls.filter((c) => c.op === 'update'),
+  };
+}
+
+/** Resolver for the common case: an article at `status` with `version` snapshots. */
+function articleAt(status: string, version: number | null): Resolver {
+  return (call) => {
+    if (call.table === 'news_articles' && call.op === 'select') {
+      return { data: { status }, error: null };
+    }
+    if (call.table === 'article_versions' && call.op === 'select') {
+      return { data: version === null ? null : { version_number: version }, error: null };
+    }
+    return { data: null, error: null };
+  };
+}
+
+describe('requestReview', () => {
+  it('pins the review to the article current version number', async () => {
+    const fake = createFakeClient(articleAt('draft', 7));
+
+    await requestReview(fake.client, {
+      articleId: 'article-1',
+      actorEmail: 'author@acta.dev',
+      comment: '  please look at the third paragraph  ',
+    });
+
+    const review = fake.inserts().find((c) => c.table === 'article_reviews');
+    expect(review?.payload).toEqual({
+      article_id: 'article-1',
+      version_number: 7,
+      state: 'requested',
+      requested_by: 'author@acta.dev',
+      comment: 'please look at the third paragraph',
+    });
+  });
+
+  it('moves a draft into in_review', async () => {
+    const fake = createFakeClient(articleAt('draft', 2));
+
+    await requestReview(fake.client, { articleId: 'article-1', actorEmail: 'a@acta.dev' });
+
+    const update = fake.updates().find((c) => c.table === 'news_articles');
+    expect(update?.payload).toEqual({ status: 'in_review' });
+    expect(update?.filters).toContainEqual(['eq', 'id', 'article-1']);
+  });
+
+  it('does not re-transition an article already in review', async () => {
+    const fake = createFakeClient(articleAt('in_review', 2));
+
+    await requestReview(fake.client, { articleId: 'article-1', actorEmail: 'a@acta.dev' });
+
+    expect(fake.inserts()).toHaveLength(1);
+    expect(fake.updates()).toHaveLength(0);
+  });
+
+  it('pins null when the article has no version snapshots yet', async () => {
+    const fake = createFakeClient(articleAt('draft', null));
+
+    await requestReview(fake.client, { articleId: 'article-1', actorEmail: 'a@acta.dev' });
+
+    expect(fake.inserts()[0].payload?.version_number).toBeNull();
+  });
+
+  it('normalises an empty comment to null', async () => {
+    const fake = createFakeClient(articleAt('draft', 1));
+
+    await requestReview(fake.client, {
+      articleId: 'article-1',
+      actorEmail: 'a@acta.dev',
+      comment: '   ',
+    });
+
+    expect(fake.inserts()[0].payload?.comment).toBeNull();
+  });
+
+  for (const status of ['published', 'scheduled', 'archived']) {
+    it(`refuses to open a review on a ${status} article`, async () => {
+      const fake = createFakeClient(articleAt(status, 1));
+
+      await expect(
+        requestReview(fake.client, { articleId: 'article-1', actorEmail: 'a@acta.dev' })
+      ).rejects.toThrow(`Cannot request review for an article in "${status}".`);
+
+      expect(fake.inserts()).toHaveLength(0);
+    });
+  }
+
+  it('throws when the article does not exist', async () => {
+    const fake = createFakeClient(() => ({ data: null, error: null }));
+
+    await expect(
+      requestReview(fake.client, { articleId: 'missing', actorEmail: 'a@acta.dev' })
+    ).rejects.toThrow('Article not found.');
+  });
+
+  it('surfaces a write error instead of silently succeeding', async () => {
+    const fake = createFakeClient((call) => {
+      if (call.table === 'news_articles' && call.op === 'select') {
+        return { data: { status: 'draft' }, error: null };
+      }
+      if (call.table === 'article_versions') return { data: { version_number: 1 }, error: null };
+      if (call.table === 'article_reviews') return { data: null, error: { message: 'rls denied' } };
+      return { data: null, error: null };
+    });
+
+    await expect(
+      requestReview(fake.client, { articleId: 'article-1', actorEmail: 'a@acta.dev' })
+    ).rejects.toMatchObject({ message: 'rls denied' });
+  });
+});
+
+describe('approve', () => {
+  it('appends a resolved approval without changing the article status', async () => {
+    const fake = createFakeClient(articleAt('in_review', 4));
+
+    await approve(fake.client, {
+      articleId: 'article-1',
+      actorEmail: 'editor@acta.dev',
+      comment: 'looks good',
+    });
+
+    const review = fake.inserts().find((c) => c.table === 'article_reviews');
+    expect(review?.payload).toMatchObject({
+      article_id: 'article-1',
+      version_number: 4,
+      state: 'approved',
+      requested_by: 'editor@acta.dev',
+      reviewer_email: 'editor@acta.dev',
+      comment: 'looks good',
+    });
+    expect(review?.payload?.resolved_at).toEqual(expect.any(String));
+
+    // Publishing stays an explicit, separate step.
+    expect(fake.updates()).toHaveLength(0);
+  });
+});
+
+describe('requestChanges', () => {
+  it('appends the event and sends the article back to draft', async () => {
+    const fake = createFakeClient(articleAt('in_review', 3));
+
+    await requestChanges(fake.client, {
+      articleId: 'article-1',
+      actorEmail: 'editor@acta.dev',
+      comment: 'needs sources',
+    });
+
+    const review = fake.inserts().find((c) => c.table === 'article_reviews');
+    expect(review?.payload).toMatchObject({
+      state: 'changes_requested',
+      reviewer_email: 'editor@acta.dev',
+      comment: 'needs sources',
+    });
+
+    const update = fake.updates().find((c) => c.table === 'news_articles');
+    expect(update?.payload).toEqual({ status: 'draft' });
+  });
+
+  it('leaves the status alone when the article is no longer in review', async () => {
+    const fake = createFakeClient(articleAt('draft', 3));
+
+    await requestChanges(fake.client, {
+      articleId: 'article-1',
+      actorEmail: 'editor@acta.dev',
+      comment: 'needs sources',
+    });
+
+    expect(fake.inserts()).toHaveLength(1);
+    expect(fake.updates()).toHaveLength(0);
+  });
+});
+
+describe('listThread', () => {
+  it('maps rows to the camelCase event shape', async () => {
+    const fake = createFakeClient(() => ({
+      data: [
+        {
+          id: 'r1',
+          article_id: 'a1',
+          version_number: 2,
+          state: 'requested',
+          requested_by: 'author@acta.dev',
+          reviewer_email: null,
+          comment: 'ready',
+          created_at: '2026-08-16T10:00:00.000Z',
+          resolved_at: null,
+        },
+      ],
+      error: null,
+    }));
+
+    const thread = await listThread(fake.client, 'a1');
+
+    expect(thread).toEqual([
+      {
+        id: 'r1',
+        articleId: 'a1',
+        versionNumber: 2,
+        state: 'requested',
+        requestedBy: 'author@acta.dev',
+        reviewerEmail: null,
+        comment: 'ready',
+        createdAt: '2026-08-16T10:00:00.000Z',
+        resolvedAt: null,
+      },
+    ]);
+  });
+});
+
+describe('listOpen', () => {
+  const article = (id: string) => ({ id, title: `Title ${id}`, slug: `slug-${id}` });
+
+  function reviewRow(over: Partial<Record<string, unknown>>) {
+    return {
+      id: 'r',
+      article_id: 'a1',
+      version_number: 1,
+      state: 'requested',
+      requested_by: 'author@acta.dev',
+      reviewer_email: null,
+      comment: null,
+      created_at: '2026-08-16T10:00:00.000Z',
+      resolved_at: null,
+      article: article('a1'),
+      ...over,
+    };
+  }
+
+  /** Rows arrive newest-first, mirroring the service's `order(created_at desc)`. */
+  function resolverFor(rows: unknown[], versions: unknown[] = []): Resolver {
+    return (call) => {
+      if (call.table === 'article_reviews') return { data: rows, error: null };
+      if (call.table === 'article_versions') return { data: versions, error: null };
+      return { data: null, error: null };
+    };
+  }
+
+  it('returns an article whose newest event is still requested', async () => {
+    const fake = createFakeClient(resolverFor([reviewRow({ id: 'r1' })]));
+
+    const open = await listOpen(fake.client);
+
+    expect(open).toHaveLength(1);
+    expect(open[0]).toMatchObject({
+      articleId: 'a1',
+      articleTitle: 'Title a1',
+      articleSlug: 'slug-a1',
+      requestedBy: 'author@acta.dev',
+      versionNumber: 1,
+    });
+  });
+
+  it('excludes an article whose newest event resolved it', async () => {
+    const fake = createFakeClient(
+      resolverFor([
+        reviewRow({ id: 'r2', state: 'approved', created_at: '2026-08-16T12:00:00.000Z' }),
+        reviewRow({ id: 'r1', state: 'requested', created_at: '2026-08-16T10:00:00.000Z' }),
+      ])
+    );
+
+    await expect(listOpen(fake.client)).resolves.toEqual([]);
+  });
+
+  it('reopens when a newer request follows a resolution', async () => {
+    const fake = createFakeClient(
+      resolverFor([
+        reviewRow({ id: 'r3', state: 'requested', created_at: '2026-08-16T14:00:00.000Z' }),
+        reviewRow({
+          id: 'r2',
+          state: 'changes_requested',
+          created_at: '2026-08-16T12:00:00.000Z',
+        }),
+        reviewRow({ id: 'r1', state: 'requested', created_at: '2026-08-16T10:00:00.000Z' }),
+      ])
+    );
+
+    const open = await listOpen(fake.client);
+    expect(open).toHaveLength(1);
+    expect(open[0].requestedAt).toBe('2026-08-16T14:00:00.000Z');
+  });
+
+  it('keeps each article separate and orders the queue oldest first', async () => {
+    const fake = createFakeClient(
+      resolverFor([
+        reviewRow({
+          id: 'rB',
+          article_id: 'a2',
+          article: article('a2'),
+          created_at: '2026-08-16T13:00:00.000Z',
+        }),
+        reviewRow({ id: 'rA', article_id: 'a1', created_at: '2026-08-16T09:00:00.000Z' }),
+      ])
+    );
+
+    const open = await listOpen(fake.client);
+
+    expect(open.map((o) => o.articleId)).toEqual(['a1', 'a2']);
+  });
+
+  it('drops rows whose article is not visible to the caller', async () => {
+    // RLS nulls the embedded article for a contributor looking at someone else's work.
+    const fake = createFakeClient(resolverFor([reviewRow({ id: 'r1', article: null })]));
+
+    await expect(listOpen(fake.client)).resolves.toEqual([]);
+  });
+
+  it('attaches the diff of the version the review was filed against', async () => {
+    const fake = createFakeClient(
+      resolverFor(
+        [reviewRow({ id: 'r1', version_number: 3 })],
+        [
+          {
+            article_id: 'a1',
+            version_number: 3,
+            diff_summary: {
+              fieldsChanged: ['content'],
+              contentAdded: 120,
+              contentRemoved: 8,
+              sectionsModified: 2,
+            },
+          },
+          { article_id: 'a1', version_number: 2, diff_summary: null },
+        ]
+      )
+    );
+
+    const open = await listOpen(fake.client);
+
+    expect(open[0].diffSummary).toEqual({
+      fieldsChanged: ['content'],
+      contentAdded: 120,
+      contentRemoved: 8,
+      sectionsModified: 2,
+    });
+  });
+
+  it('falls back to a null diff when the version has none', async () => {
+    const fake = createFakeClient(resolverFor([reviewRow({ id: 'r1', version_number: 9 })], []));
+
+    const open = await listOpen(fake.client);
+    expect(open[0].diffSummary).toBeNull();
+  });
+
+  it('returns an empty queue without querying versions', async () => {
+    const fake = createFakeClient(resolverFor([]));
+
+    await expect(listOpen(fake.client)).resolves.toEqual([]);
+    expect(fake.calls.filter((c) => c.table === 'article_versions')).toHaveLength(0);
+  });
+});

--- a/src/components/modules/admin/services/__tests__/rls.integration.test.ts
+++ b/src/components/modules/admin/services/__tests__/rls.integration.test.ts
@@ -1,0 +1,285 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Database } from '@/lib/supabase/database.types';
+
+/**
+ * RLS integration tests against a local Supabase.
+ *
+ * Opt-in, because they need a running database and real auth users:
+ *
+ *   npm run db:start
+ *   npm run db:reset
+ *   RUN_RLS_TESTS=1 npm test
+ *
+ * The pure unit tests cover the same rules from the application side; this
+ * suite proves the *database* enforces them even when the REST API is called
+ * directly, which is the point of putting the guard in Postgres.
+ */
+
+const URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+const enabled = process.env.RUN_RLS_TESTS === '1' && Boolean(URL && ANON_KEY && SERVICE_KEY);
+
+const suffix = Math.random().toString(36).slice(2, 8);
+const PASSWORD = 'rls-test-password-1234';
+
+const emails = {
+  owner: `rls-owner-${suffix}@acta.test`,
+  editor: `rls-editor-${suffix}@acta.test`,
+  author: `rls-author-${suffix}@acta.test`,
+  contributor: `rls-contributor-${suffix}@acta.test`,
+};
+
+type Client = SupabaseClient<Database>;
+
+let admin: Client;
+const clients: Record<keyof typeof emails, Client> = {} as never;
+const authorIds: { a1: string; a2: string } = { a1: '', a2: '' };
+const articleIds: { authorDraft: string; contributorDraft: string } = {
+  authorDraft: '',
+  contributorDraft: '',
+};
+const userIds: string[] = [];
+
+async function signIn(email: string): Promise<Client> {
+  const client = createClient<Database>(URL!, ANON_KEY!, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  const { error } = await client.auth.signInWithPassword({ email, password: PASSWORD });
+  if (error) throw error;
+  return client;
+}
+
+describe.skipIf(!enabled)('editorial RLS', () => {
+  beforeAll(async () => {
+    admin = createClient<Database>(URL!, SERVICE_KEY!, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+
+    const { data: authors, error: authorError } = await admin
+      .from('authors')
+      .insert([
+        { slug: `rls-a1-${suffix}`, name: `RLS Author One ${suffix}` },
+        { slug: `rls-a2-${suffix}`, name: `RLS Author Two ${suffix}` },
+      ])
+      .select('id, slug');
+    if (authorError) throw authorError;
+
+    authorIds.a1 = authors!.find((a) => a.slug === `rls-a1-${suffix}`)!.id;
+    authorIds.a2 = authors!.find((a) => a.slug === `rls-a2-${suffix}`)!.id;
+
+    const roleAuthor: Record<keyof typeof emails, string | null> = {
+      owner: null,
+      editor: null,
+      author: authorIds.a1,
+      contributor: authorIds.a2,
+    };
+
+    for (const key of Object.keys(emails) as (keyof typeof emails)[]) {
+      const { data, error } = await admin.auth.admin.createUser({
+        email: emails[key],
+        password: PASSWORD,
+        email_confirm: true,
+      });
+      if (error) throw error;
+      userIds.push(data.user!.id);
+
+      const { error: rowError } = await admin
+        .from('admin_users')
+        .insert({ email: emails[key], role: key, author_id: roleAuthor[key] });
+      if (rowError) throw rowError;
+
+      clients[key] = await signIn(emails[key]);
+    }
+
+    const { data: articles, error: articleError } = await admin
+      .from('news_articles')
+      .insert([
+        {
+          slug: `rls-author-draft-${suffix}`,
+          title: 'Author draft',
+          summary: 's',
+          content: 'c',
+          category: 'product',
+          status: 'draft',
+          author_id: authorIds.a1,
+        },
+        {
+          slug: `rls-contributor-draft-${suffix}`,
+          title: 'Contributor draft',
+          summary: 's',
+          content: 'c',
+          category: 'product',
+          status: 'draft',
+          author_id: authorIds.a2,
+        },
+      ])
+      .select('id, slug');
+    if (articleError) throw articleError;
+
+    articleIds.authorDraft = articles!.find((a) => a.slug === `rls-author-draft-${suffix}`)!.id;
+    articleIds.contributorDraft = articles!.find(
+      (a) => a.slug === `rls-contributor-draft-${suffix}`
+    )!.id;
+  }, 60_000);
+
+  afterAll(async () => {
+    if (!admin) return;
+    await admin.from('news_articles').delete().like('slug', `rls-%-${suffix}`);
+    await admin.from('admin_users').delete().in('email', Object.values(emails));
+    await admin.from('authors').delete().in('id', [authorIds.a1, authorIds.a2]);
+    for (const id of userIds) await admin.auth.admin.deleteUser(id);
+  }, 60_000);
+
+  it('hides another author’s draft from a contributor', async () => {
+    const { data, error } = await clients.contributor
+      .from('news_articles')
+      .select('id, slug')
+      .in('id', [articleIds.authorDraft, articleIds.contributorDraft]);
+
+    expect(error).toBeNull();
+    expect(data?.map((row) => row.id)).toEqual([articleIds.contributorDraft]);
+  });
+
+  it('shows the whole desk to an author', async () => {
+    const { data, error } = await clients.author
+      .from('news_articles')
+      .select('id')
+      .in('id', [articleIds.authorDraft, articleIds.contributorDraft]);
+
+    expect(error).toBeNull();
+    expect(data).toHaveLength(2);
+  });
+
+  it('refuses a contributor editing an article they do not own', async () => {
+    const { data } = await clients.contributor
+      .from('news_articles')
+      .update({ title: 'hijacked' })
+      .eq('id', articleIds.authorDraft)
+      .select('id');
+
+    expect(data ?? []).toHaveLength(0);
+  });
+
+  it('refuses a contributor publishing their own article', async () => {
+    const { error } = await clients.contributor
+      .from('news_articles')
+      .update({ status: 'published' })
+      .eq('id', articleIds.contributorDraft);
+
+    expect(error).not.toBeNull();
+    expect(error?.message).toContain('insufficient role');
+  });
+
+  it('refuses a contributor scheduling their own article', async () => {
+    const { error } = await clients.contributor
+      .from('news_articles')
+      .update({ status: 'scheduled', scheduled_at: new Date().toISOString() })
+      .eq('id', articleIds.contributorDraft);
+
+    expect(error).not.toBeNull();
+    expect(error?.message).toContain('insufficient role');
+  });
+
+  it('rejects an invalid transition even for an owner', async () => {
+    await admin
+      .from('news_articles')
+      .update({ status: 'archived' })
+      .eq('id', articleIds.authorDraft);
+
+    const { error } = await clients.owner
+      .from('news_articles')
+      .update({ status: 'published' })
+      .eq('id', articleIds.authorDraft);
+
+    expect(error).not.toBeNull();
+    expect(error?.message).toContain('invalid status transition');
+
+    await admin.from('news_articles').update({ status: 'draft' }).eq('id', articleIds.authorDraft);
+  });
+
+  it('lets an editor publish and stamps published_at', async () => {
+    const { error } = await clients.editor
+      .from('news_articles')
+      .update({ status: 'published' })
+      .eq('id', articleIds.authorDraft);
+
+    expect(error).toBeNull();
+
+    const { data } = await admin
+      .from('news_articles')
+      .select('status, published_at')
+      .eq('id', articleIds.authorDraft)
+      .single();
+
+    expect(data?.status).toBe('published');
+    expect(data?.published_at).not.toBeNull();
+  });
+
+  it('writes an audit row for every status change', async () => {
+    const { data } = await admin
+      .from('editorial_audit_log')
+      .select('actor_email, from_status, to_status')
+      .eq('entity_id', articleIds.authorDraft)
+      .order('created_at', { ascending: true });
+
+    expect(data?.length).toBeGreaterThan(0);
+    expect(data?.at(-1)).toMatchObject({
+      actor_email: emails.editor,
+      from_status: 'draft',
+      to_status: 'published',
+    });
+  });
+
+  it('keeps article_reviews append-only', async () => {
+    const { error: insertError } = await clients.contributor.from('article_reviews').insert({
+      article_id: articleIds.contributorDraft,
+      state: 'requested',
+      requested_by: emails.contributor,
+      comment: 'please review',
+    });
+    expect(insertError).toBeNull();
+
+    const { data: updated } = await clients.owner
+      .from('article_reviews')
+      .update({ comment: 'tampered' })
+      .eq('article_id', articleIds.contributorDraft)
+      .select('id');
+    expect(updated ?? []).toHaveLength(0);
+
+    const { data: deleted } = await clients.owner
+      .from('article_reviews')
+      .delete()
+      .eq('article_id', articleIds.contributorDraft)
+      .select('id');
+    expect(deleted ?? []).toHaveLength(0);
+  });
+
+  it('refuses a contributor appending an approval', async () => {
+    const { error } = await clients.contributor.from('article_reviews').insert({
+      article_id: articleIds.contributorDraft,
+      state: 'approved',
+      requested_by: emails.contributor,
+    });
+
+    expect(error).not.toBeNull();
+  });
+
+  it('lets only an owner change roles', async () => {
+    const { data: denied } = await clients.editor
+      .from('admin_users')
+      .update({ role: 'owner' })
+      .eq('email', emails.editor)
+      .select('email');
+    expect(denied ?? []).toHaveLength(0);
+
+    const { data: allowed } = await clients.owner
+      .from('admin_users')
+      .update({ role: 'author' })
+      .eq('email', emails.contributor)
+      .select('email');
+    expect(allowed).toHaveLength(1);
+  });
+});

--- a/src/components/modules/admin/services/__tests__/roles.test.ts
+++ b/src/components/modules/admin/services/__tests__/roles.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AdminSession, EditorialRole } from '@/@types/editorial';
+import { ForbiddenError } from '@/lib/editorial/permissions';
+
+/**
+ * `roles.service` reaches `auth.service` -> `@/lib/supabase/server`, which
+ * imports `server-only` and would refuse to load under a plain Node runner.
+ * Both are mocked so the real `requireRole` can be exercised.
+ */
+const requireAdmin = vi.fn();
+
+vi.mock('../auth.service', () => ({
+  requireAdmin: () => requireAdmin(),
+  getCurrentAdmin: () => requireAdmin(),
+}));
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: async () => {
+    throw new Error('not used in this test');
+  },
+}));
+
+const { requireRole, getCurrentRole } = await import('../roles.service');
+
+const ALL_ROLES: EditorialRole[] = ['owner', 'editor', 'author', 'contributor'];
+
+function session(role: EditorialRole): AdminSession {
+  return {
+    id: 'user-1',
+    email: `${role}@acta.dev`,
+    role,
+    authorId: null,
+    displayName: null,
+  };
+}
+
+beforeEach(() => {
+  requireAdmin.mockReset();
+});
+
+describe('requireRole', () => {
+  it('returns the session when the role is allowed', async () => {
+    requireAdmin.mockResolvedValue(session('editor'));
+
+    const result = await requireRole('owner', 'editor');
+
+    expect(result.role).toBe('editor');
+    expect(result.email).toBe('editor@acta.dev');
+  });
+
+  it('rejects each insufficient role for a publish-level action', async () => {
+    for (const role of ['author', 'contributor'] as EditorialRole[]) {
+      requireAdmin.mockResolvedValue(session(role));
+
+      await expect(requireRole('owner', 'editor')).rejects.toThrow(ForbiddenError);
+      await expect(requireRole('owner', 'editor')).rejects.toThrow(
+        `role ${role} cannot perform this action`
+      );
+    }
+  });
+
+  it('rejects every non-owner for an owner-only action', async () => {
+    for (const role of ALL_ROLES) {
+      requireAdmin.mockResolvedValue(session(role));
+
+      if (role === 'owner') {
+        await expect(requireRole('owner')).resolves.toMatchObject({ role: 'owner' });
+      } else {
+        await expect(requireRole('owner')).rejects.toThrow(ForbiddenError);
+      }
+    }
+  });
+
+  it('accepts every role when all four are listed', async () => {
+    for (const role of ALL_ROLES) {
+      requireAdmin.mockResolvedValue(session(role));
+      await expect(requireRole(...ALL_ROLES)).resolves.toMatchObject({ role });
+    }
+  });
+
+  it('rejects everything when the allow-list is empty', async () => {
+    for (const role of ALL_ROLES) {
+      requireAdmin.mockResolvedValue(session(role));
+      await expect(requireRole()).rejects.toThrow(ForbiddenError);
+    }
+  });
+
+  it('propagates the redirect from requireAdmin for anonymous callers', async () => {
+    // `requireAdmin` redirects rather than returning null; the role check must
+    // never run in that case.
+    requireAdmin.mockRejectedValue(new Error('NEXT_REDIRECT'));
+
+    await expect(requireRole('owner')).rejects.toThrow('NEXT_REDIRECT');
+  });
+});
+
+describe('getCurrentRole', () => {
+  it('returns the signed-in role', async () => {
+    requireAdmin.mockResolvedValue(session('author'));
+    await expect(getCurrentRole()).resolves.toBe('author');
+  });
+
+  it('returns null when there is no admin', async () => {
+    requireAdmin.mockResolvedValue(null);
+    await expect(getCurrentRole()).resolves.toBeNull();
+  });
+});

--- a/src/components/modules/admin/services/__tests__/scheduling.test.ts
+++ b/src/components/modules/admin/services/__tests__/scheduling.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { TypedSupabaseClient } from '@/lib/supabase';
+import {
+  publishScheduledArticles,
+  schedule,
+  type PublishedArticle,
+  type SchedulingDeps,
+} from '../scheduling.service';
+
+/**
+ * A fake `news_articles` table that reproduces the two Postgres behaviours the
+ * cron relies on:
+ *
+ *  1. A conditional `UPDATE ... WHERE status='scheduled'` re-evaluates its
+ *     predicate *after* acquiring the row lock, so a second concurrent
+ *     statement sees the committed result of the first and matches nothing.
+ *  2. `published_at` is stamped by the trigger on the way to `published`.
+ *
+ * Statements are serialised through a lock and yield to the event loop before
+ * applying, so two overlapping `publishScheduledArticles()` calls genuinely
+ * interleave rather than running one after the other.
+ */
+interface FakeRow {
+  id: string;
+  slug: string;
+  status: string;
+  scheduled_at: string | null;
+  published_at: string | null;
+}
+
+type Filter = ['eq' | 'lte', string, string];
+
+function createFakeClient(rows: FakeRow[]) {
+  const statements: Filter[][] = [];
+  let lock: Promise<void> = Promise.resolve();
+
+  function matches(row: FakeRow, filters: Filter[]): boolean {
+    return filters.every(([op, column, value]) => {
+      const current = row[column as keyof FakeRow];
+      if (op === 'eq') return current === value;
+      return current !== null && String(current) <= value;
+    });
+  }
+
+  const client = {
+    from() {
+      return {
+        update(patch: Record<string, unknown>) {
+          const filters: Filter[] = [];
+
+          const builder = {
+            eq(column: string, value: string) {
+              filters.push(['eq', column, value]);
+              return builder;
+            },
+            lte(column: string, value: string) {
+              filters.push(['lte', column, value]);
+              return builder;
+            },
+            select() {
+              const previous = lock;
+              let release!: () => void;
+              lock = new Promise<void>((resolve) => {
+                release = resolve;
+              });
+
+              return (async () => {
+                await previous; // row lock
+                await new Promise((resolve) => setTimeout(resolve, 0)); // real interleaving
+                statements.push(filters);
+
+                const matched = rows.filter((row) => matches(row, filters));
+                for (const row of matched) {
+                  Object.assign(row, patch);
+                  if (patch.status === 'published' && row.published_at === null) {
+                    row.published_at = new Date().toISOString();
+                  }
+                }
+
+                release();
+                return {
+                  data: matched.map((row) => ({ id: row.id, slug: row.slug })),
+                  error: null,
+                };
+              })();
+            },
+          };
+
+          return builder;
+        },
+      };
+    },
+  };
+
+  return { client: client as unknown as TypedSupabaseClient, rows, statements };
+}
+
+function createDeps(rows: FakeRow[], now = new Date('2026-08-16T12:00:00.000Z')) {
+  const fake = createFakeClient(rows);
+  const attested: string[] = [];
+  const revalidated: string[] = [];
+
+  const deps: SchedulingDeps = {
+    client: fake.client,
+    revalidate: (path) => {
+      revalidated.push(path);
+    },
+    attest: async (article: PublishedArticle) => {
+      attested.push(article.slug);
+    },
+    now: () => now,
+  };
+
+  return { deps, fake, attested, revalidated };
+}
+
+function scheduledRow(id: string, offsetMinutes: number): FakeRow {
+  return {
+    id,
+    slug: `article-${id}`,
+    status: 'scheduled',
+    scheduled_at: new Date(
+      new Date('2026-08-16T12:00:00.000Z').getTime() + offsetMinutes * 60_000
+    ).toISOString(),
+    published_at: null,
+  };
+}
+
+describe('publishScheduledArticles', () => {
+  it('publishes only articles whose time has arrived', async () => {
+    const rows = [scheduledRow('a', -10), scheduledRow('b', -1), scheduledRow('c', 60)];
+    const { deps, attested } = createDeps(rows);
+
+    const result = await publishScheduledArticles(deps);
+
+    expect(result.publishedCount).toBe(2);
+    expect(result.published.map((a) => a.id).sort()).toEqual(['a', 'b']);
+    expect(attested.sort()).toEqual(['article-a', 'article-b']);
+    expect(rows.find((r) => r.id === 'c')?.status).toBe('scheduled');
+  });
+
+  it('stamps published_at on the rows it publishes', async () => {
+    const rows = [scheduledRow('a', -5)];
+    const { deps } = createDeps(rows);
+
+    await publishScheduledArticles(deps);
+
+    expect(rows[0].status).toBe('published');
+    expect(rows[0].published_at).not.toBeNull();
+  });
+
+  it('filters on status=scheduled so the update is conditional, not read-then-write', async () => {
+    const { deps, fake } = createDeps([scheduledRow('a', -5)]);
+
+    await publishScheduledArticles(deps);
+
+    expect(fake.statements).toHaveLength(1);
+    expect(fake.statements[0]).toContainEqual(['eq', 'status', 'scheduled']);
+    expect(
+      fake.statements[0].some(([op, column]) => op === 'lte' && column === 'scheduled_at')
+    ).toBe(true);
+  });
+
+  it('is idempotent: a second sequential run publishes nothing', async () => {
+    const rows = [scheduledRow('a', -5), scheduledRow('b', -5)];
+    const { deps, attested } = createDeps(rows);
+
+    const first = await publishScheduledArticles(deps);
+    const second = await publishScheduledArticles(deps);
+
+    expect(first.publishedCount).toBe(2);
+    expect(second.publishedCount).toBe(0);
+    expect(second.published).toEqual([]);
+    expect(attested).toHaveLength(2);
+  });
+
+  it('never publishes the same article twice under two overlapping runs', async () => {
+    const rows = [scheduledRow('a', -5), scheduledRow('b', -5), scheduledRow('c', -5)];
+    const { deps, attested, revalidated } = createDeps(rows);
+
+    // Both runs start before either completes.
+    const [first, second] = await Promise.all([
+      publishScheduledArticles(deps),
+      publishScheduledArticles(deps),
+    ]);
+
+    const publishedIds = [...first.published, ...second.published].map((a) => a.id);
+
+    expect(publishedIds).toHaveLength(3);
+    expect(new Set(publishedIds).size).toBe(3); // no duplicates
+    expect(first.publishedCount + second.publishedCount).toBe(3);
+
+    // Exactly one of the two runs did the work; the other was a no-op.
+    expect([first.publishedCount, second.publishedCount].sort()).toEqual([0, 3]);
+
+    // Follow-up work also happens exactly once per article.
+    expect(attested.sort()).toEqual(['article-a', 'article-b', 'article-c']);
+    expect(revalidated.filter((p) => p === '/news/article-a')).toHaveLength(1);
+  });
+
+  it('does no follow-up work when nothing is due', async () => {
+    const { deps, attested, revalidated } = createDeps([scheduledRow('a', 120)]);
+
+    const result = await publishScheduledArticles(deps);
+
+    expect(result).toEqual({ publishedCount: 0, published: [], errors: [] });
+    expect(attested).toEqual([]);
+    expect(revalidated).toEqual([]);
+  });
+
+  it('revalidates the home page, the index and each published article', async () => {
+    const { deps, revalidated } = createDeps([scheduledRow('a', -5), scheduledRow('b', -5)]);
+
+    await publishScheduledArticles(deps);
+
+    expect(revalidated).toEqual(['/', '/news', '/news/article-a', '/news/article-b']);
+  });
+
+  it('reports attestation failures without unpublishing the article', async () => {
+    const rows = [scheduledRow('a', -5)];
+    const { deps } = createDeps(rows);
+    deps.attest = vi.fn().mockRejectedValue(new Error('horizon unreachable'));
+
+    const result = await publishScheduledArticles(deps);
+
+    expect(result.publishedCount).toBe(1);
+    expect(rows[0].status).toBe('published');
+    expect(result.errors).toEqual(['attestation failed for article-a: horizon unreachable']);
+  });
+
+  it('surfaces a query error instead of throwing', async () => {
+    const failing = {
+      from: () => ({
+        update: () => ({
+          eq: () => ({
+            lte: () => ({
+              select: async () => ({ data: null, error: { message: 'permission denied' } }),
+            }),
+          }),
+        }),
+      }),
+    } as unknown as TypedSupabaseClient;
+
+    const result = await publishScheduledArticles({
+      client: failing,
+      revalidate: () => {},
+      attest: async () => {},
+      now: () => new Date(),
+    });
+
+    expect(result).toEqual({ publishedCount: 0, published: [], errors: ['permission denied'] });
+  });
+});
+
+describe('schedule', () => {
+  it('rejects an invalid date before touching the database', async () => {
+    const client = {
+      from: () => {
+        throw new Error('should not be called');
+      },
+    } as unknown as TypedSupabaseClient;
+
+    await expect(
+      schedule(client, { articleId: 'a', scheduledAt: new Date('not-a-date') })
+    ).rejects.toThrow('Invalid schedule date.');
+  });
+
+  it('writes status=scheduled and the ISO timestamp', async () => {
+    const update = vi.fn().mockReturnValue({ eq: async () => ({ error: null }) });
+    const client = { from: () => ({ update }) } as unknown as TypedSupabaseClient;
+    const when = new Date('2026-09-01T09:30:00.000Z');
+
+    await schedule(client, { articleId: 'a', scheduledAt: when });
+
+    expect(update).toHaveBeenCalledWith({
+      status: 'scheduled',
+      scheduled_at: '2026-09-01T09:30:00.000Z',
+    });
+  });
+});

--- a/src/components/modules/admin/services/attestation.service.ts
+++ b/src/components/modules/admin/services/attestation.service.ts
@@ -1,0 +1,100 @@
+/**
+ * On-chain attestation for newly published articles.
+ *
+ * Reuses the existing Stellar helpers (`computeArticleHash`, `submitAttestation`)
+ * rather than reimplementing anchoring, which is the reason scheduled
+ * publishing runs as a Next.js route handler instead of a Deno edge function.
+ *
+ * The flow is deliberately best-effort: a Stellar outage must never stop an
+ * article from going live. Failures are recorded on the attestation row
+ * (`status = 'failed'`) and surfaced in the cron response.
+ */
+
+import type { PublishedArticle } from './scheduling.service';
+import type { TypedSupabaseClient } from '@/lib/supabase';
+import { computeArticleHash } from '@/lib/stellar/hash';
+import { getActiveNetwork } from '@/lib/stellar/config';
+
+/**
+ * Anchor an article's published content hash on Stellar.
+ *
+ * Idempotent: `article_attestations` is unique on `(article_id, version)`, so
+ * a repeat call for a version that was already attested is a no-op.
+ */
+export async function attestPublishedArticle(
+  supabase: TypedSupabaseClient,
+  article: PublishedArticle
+): Promise<void> {
+  const { data: row, error } = await supabase
+    .from('news_articles')
+    .select('id, slug, title, summary, content, published_at')
+    .eq('id', article.id)
+    .maybeSingle();
+
+  if (error) throw error;
+  if (!row) return;
+
+  const contentHash = computeArticleHash({
+    title: row.title,
+    summary: row.summary,
+    content: row.content,
+    published_at: row.published_at ?? '',
+  });
+
+  const { data: latestVersion } = await supabase
+    .from('article_versions')
+    .select('version_number')
+    .eq('article_id', article.id)
+    .order('version_number', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  const version = latestVersion?.version_number ?? 1;
+
+  // Claim the (article_id, version) slot. An empty result means another run
+  // already attested this version — nothing left to do.
+  const { data: claimed, error: claimError } = await supabase
+    .from('article_attestations')
+    .upsert(
+      {
+        article_id: article.id,
+        version,
+        content_hash: contentHash,
+        network: getActiveNetwork(),
+        status: 'pending',
+      },
+      { onConflict: 'article_id,version', ignoreDuplicates: true }
+    )
+    .select('id');
+
+  if (claimError) throw claimError;
+
+  const attestationId = claimed?.[0]?.id;
+  if (!attestationId) return;
+
+  if (!process.env.STELLAR_BLOG_SECRET_KEY) {
+    console.info('[stellar] STELLAR_BLOG_SECRET_KEY not set — skipping attestation submission.');
+    return;
+  }
+
+  try {
+    const { submitAttestation } = await import('@/lib/stellar/attestation');
+    const result = await submitAttestation(row.slug, contentHash);
+
+    await supabase
+      .from('article_attestations')
+      .update({
+        stellar_tx_hash: result.stellar_tx_hash,
+        ledger: result.ledger,
+        status: 'confirmed',
+      })
+      .eq('id', attestationId);
+  } catch (err) {
+    await supabase
+      .from('article_attestations')
+      .update({ status: 'failed' })
+      .eq('id', attestationId);
+
+    throw err instanceof Error ? err : new Error(String(err));
+  }
+}

--- a/src/components/modules/admin/services/auth.service.ts
+++ b/src/components/modules/admin/services/auth.service.ts
@@ -1,10 +1,14 @@
 import { redirect } from 'next/navigation';
 import { createClient } from '@/lib/supabase/server';
+import type { AdminSession, EditorialRole } from '@/@types/editorial';
 
-export interface CurrentAdmin {
-  id: string;
-  email: string;
-}
+/**
+ * The signed-in admin, enriched with their editorial role.
+ *
+ * `CurrentAdmin` is kept as an alias of `AdminSession` so existing callers
+ * (`requireAdmin()`) keep working while gaining `role` / `authorId`.
+ */
+export type CurrentAdmin = AdminSession;
 
 function providerOf(user: { app_metadata?: { provider?: string } }) {
   return user.app_metadata?.provider ?? 'unknown';
@@ -22,7 +26,7 @@ export async function getCurrentAdmin(): Promise<CurrentAdmin | null> {
 
   const { data: adminRow } = await supabase
     .from('admin_users')
-    .select('email')
+    .select('email, role, author_id, display_name')
     .eq('email', normalizedEmail)
     .maybeSingle();
 
@@ -31,6 +35,11 @@ export async function getCurrentAdmin(): Promise<CurrentAdmin | null> {
   return {
     id: user.id,
     email: normalizedEmail,
+    // Defensive default: a row written before 0006 (or by a client that omits
+    // the column) is treated as the least-privileged role that can still work.
+    role: (adminRow.role ?? 'contributor') as EditorialRole,
+    authorId: adminRow.author_id ?? null,
+    displayName: adminRow.display_name ?? null,
   };
 }
 

--- a/src/components/modules/admin/services/news.service.ts
+++ b/src/components/modules/admin/services/news.service.ts
@@ -23,6 +23,7 @@ const ADMIN_ARTICLE_SELECT = `
   author_id,
   reading_time_minutes,
   published_at,
+  scheduled_at,
   created_at,
   updated_at,
   author:authors ( id, name, slug ),
@@ -36,7 +37,9 @@ export interface AdminNewsListItem {
   status: Database['public']['Enums']['news_status'];
   category: Database['public']['Enums']['news_category'];
   authorName: string;
+  authorId: string;
   publishedAt: string | null;
+  scheduledAt: string | null;
   updatedAt: string;
 }
 
@@ -52,6 +55,7 @@ export interface AdminNewsEditorData {
   authorId: string;
   readingTimeMinutes: number;
   publishedAt: string;
+  scheduledAt: string | null;
   tags: string[];
 }
 
@@ -83,7 +87,9 @@ export async function fetchAdminNewsList(
     status: row.status,
     category: row.category,
     authorName: row.author?.name ?? 'Unknown',
+    authorId: row.author_id,
     publishedAt: row.published_at,
+    scheduledAt: row.scheduled_at,
     updatedAt: row.updated_at,
   }));
 }
@@ -114,6 +120,7 @@ export async function fetchAdminNewsById(
     authorId: row.author_id,
     readingTimeMinutes: row.reading_time_minutes,
     publishedAt: row.published_at ? row.published_at.slice(0, 16) : '',
+    scheduledAt: row.scheduled_at,
     tags: row.tags.map((tag: ArticleTagRow) => tag.tag_slug),
   };
 }

--- a/src/components/modules/admin/services/reviews.service.ts
+++ b/src/components/modules/admin/services/reviews.service.ts
@@ -1,0 +1,255 @@
+/**
+ * Review queue.
+ *
+ * `article_reviews` is an append-only event log (see the RLS block in
+ * `0006_editorial_workflow.sql`): requesting a review appends a `requested`
+ * row, approving appends an `approved` row, asking for changes appends a
+ * `changes_requested` row. Nothing is ever updated or deleted, so the full
+ * thread stays readable and the table needs no UPDATE policy.
+ *
+ * A review is therefore *open* when the newest event for an article is
+ * `requested`.
+ */
+
+import type { ArticleReviewEvent, OpenReviewItem, ReviewState } from '@/@types/editorial';
+import type { ArticleVersionDiffSummary } from '@/@types/news';
+import type { Json, TypedSupabaseClient } from '@/lib/supabase';
+
+type ReviewRow = {
+  id: string;
+  article_id: string;
+  version_number: number | null;
+  state: ReviewState;
+  requested_by: string;
+  reviewer_email: string | null;
+  comment: string | null;
+  created_at: string;
+  resolved_at: string | null;
+};
+
+const REVIEW_COLUMNS =
+  'id, article_id, version_number, state, requested_by, reviewer_email, comment, created_at, resolved_at';
+
+function mapEvent(row: ReviewRow): ArticleReviewEvent {
+  return {
+    id: row.id,
+    articleId: row.article_id,
+    versionNumber: row.version_number,
+    state: row.state,
+    requestedBy: row.requested_by,
+    reviewerEmail: row.reviewer_email,
+    comment: row.comment,
+    createdAt: row.created_at,
+    resolvedAt: row.resolved_at,
+  };
+}
+
+function mapDiffSummary(raw: Json | null | undefined): ArticleVersionDiffSummary | null {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const r = raw as Record<string, Json>;
+  return {
+    fieldsChanged: Array.isArray(r.fieldsChanged) ? (r.fieldsChanged as string[]) : [],
+    contentAdded: typeof r.contentAdded === 'number' ? r.contentAdded : 0,
+    contentRemoved: typeof r.contentRemoved === 'number' ? r.contentRemoved : 0,
+    sectionsModified: typeof r.sectionsModified === 'number' ? r.sectionsModified : 0,
+  };
+}
+
+/** The version number a review should be pinned to: the article's latest snapshot. */
+async function currentVersionNumber(
+  supabase: TypedSupabaseClient,
+  articleId: string
+): Promise<number | null> {
+  const { data } = await supabase
+    .from('article_versions')
+    .select('version_number')
+    .eq('article_id', articleId)
+    .order('version_number', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  return data?.version_number ?? null;
+}
+
+/**
+ * Submit an article for review.
+ *
+ * Appends a `requested` event pinned to the article's current version number
+ * and moves the article into `in_review`.
+ */
+export async function requestReview(
+  supabase: TypedSupabaseClient,
+  params: { articleId: string; actorEmail: string; comment?: string | null }
+): Promise<void> {
+  const { data: article, error: articleError } = await supabase
+    .from('news_articles')
+    .select('status')
+    .eq('id', params.articleId)
+    .maybeSingle();
+
+  if (articleError) throw articleError;
+  if (!article) throw new Error('Article not found.');
+
+  if (article.status !== 'draft' && article.status !== 'in_review') {
+    throw new Error(`Cannot request review for an article in "${article.status}".`);
+  }
+
+  const versionNumber = await currentVersionNumber(supabase, params.articleId);
+
+  const { error: insertError } = await supabase.from('article_reviews').insert({
+    article_id: params.articleId,
+    version_number: versionNumber,
+    state: 'requested',
+    requested_by: params.actorEmail,
+    comment: params.comment?.trim() || null,
+  });
+
+  if (insertError) throw insertError;
+
+  if (article.status === 'draft') {
+    const { error: statusError } = await supabase
+      .from('news_articles')
+      .update({ status: 'in_review' })
+      .eq('id', params.articleId);
+
+    if (statusError) throw statusError;
+  }
+}
+
+/** Approve an open review. The article stays in `in_review` until an editor
+ *  publishes or schedules it explicitly. */
+export async function approve(
+  supabase: TypedSupabaseClient,
+  params: { articleId: string; actorEmail: string; comment?: string | null }
+): Promise<void> {
+  await appendResolution(supabase, { ...params, state: 'approved' });
+}
+
+/** Request changes: appends the event and sends the article back to `draft`. */
+export async function requestChanges(
+  supabase: TypedSupabaseClient,
+  params: { articleId: string; actorEmail: string; comment?: string | null }
+): Promise<void> {
+  await appendResolution(supabase, { ...params, state: 'changes_requested' });
+
+  const { data: article } = await supabase
+    .from('news_articles')
+    .select('status')
+    .eq('id', params.articleId)
+    .maybeSingle();
+
+  if (article?.status === 'in_review') {
+    const { error } = await supabase
+      .from('news_articles')
+      .update({ status: 'draft' })
+      .eq('id', params.articleId);
+
+    if (error) throw error;
+  }
+}
+
+async function appendResolution(
+  supabase: TypedSupabaseClient,
+  params: {
+    articleId: string;
+    actorEmail: string;
+    comment?: string | null;
+    state: Exclude<ReviewState, 'requested'>;
+  }
+): Promise<void> {
+  const versionNumber = await currentVersionNumber(supabase, params.articleId);
+
+  const { error } = await supabase.from('article_reviews').insert({
+    article_id: params.articleId,
+    version_number: versionNumber,
+    state: params.state,
+    // `requested_by` records the actor on every event row; RLS checks it
+    // against the caller's own email.
+    requested_by: params.actorEmail,
+    reviewer_email: params.actorEmail,
+    comment: params.comment?.trim() || null,
+    resolved_at: new Date().toISOString(),
+  });
+
+  if (error) throw error;
+}
+
+/** The full review thread for one article, oldest first. */
+export async function listThread(
+  supabase: TypedSupabaseClient,
+  articleId: string
+): Promise<ArticleReviewEvent[]> {
+  const { data, error } = await supabase
+    .from('article_reviews')
+    .select(REVIEW_COLUMNS)
+    .eq('article_id', articleId)
+    .order('created_at', { ascending: true });
+
+  if (error) throw error;
+  return ((data ?? []) as unknown as ReviewRow[]).map(mapEvent);
+}
+
+/**
+ * Every article whose newest review event is still `requested`.
+ *
+ * PostgREST has no `distinct on`, so the newest event per article is picked in
+ * JS. The desk is small enough that fetching the ordered log is cheaper than a
+ * view or an RPC, and it keeps the schema surface minimal.
+ */
+export async function listOpen(supabase: TypedSupabaseClient): Promise<OpenReviewItem[]> {
+  const { data, error } = await supabase
+    .from('article_reviews')
+    .select(`${REVIEW_COLUMNS}, article:news_articles ( id, title, slug )`)
+    .order('created_at', { ascending: false });
+
+  if (error) throw error;
+
+  type JoinedRow = ReviewRow & { article: { id: string; title: string; slug: string } | null };
+  const rows = (data ?? []) as unknown as JoinedRow[];
+
+  const newestByArticle = new Map<string, JoinedRow>();
+  for (const row of rows) {
+    // Rows arrive newest-first, so the first one seen per article wins.
+    if (!newestByArticle.has(row.article_id)) newestByArticle.set(row.article_id, row);
+  }
+
+  const open = [...newestByArticle.values()].filter(
+    (row) => row.state === 'requested' && row.article !== null
+  );
+
+  if (open.length === 0) return [];
+
+  // Attach the diff of the version each review was filed against.
+  const diffByKey = await fetchDiffSummaries(supabase, open);
+
+  return open
+    .map((row) => ({
+      articleId: row.article_id,
+      articleTitle: row.article?.title ?? 'Untitled',
+      articleSlug: row.article?.slug ?? '',
+      requestedBy: row.requested_by,
+      versionNumber: row.version_number,
+      comment: row.comment,
+      requestedAt: row.created_at,
+      diffSummary: diffByKey.get(`${row.article_id}:${row.version_number}`) ?? null,
+    }))
+    .sort((a, b) => a.requestedAt.localeCompare(b.requestedAt));
+}
+
+async function fetchDiffSummaries(
+  supabase: TypedSupabaseClient,
+  rows: { article_id: string; version_number: number | null }[]
+): Promise<Map<string, ArticleVersionDiffSummary | null>> {
+  const articleIds = [...new Set(rows.map((r) => r.article_id))];
+
+  const { data } = await supabase
+    .from('article_versions')
+    .select('article_id, version_number, diff_summary')
+    .in('article_id', articleIds);
+
+  const map = new Map<string, ArticleVersionDiffSummary | null>();
+  for (const row of data ?? []) {
+    map.set(`${row.article_id}:${row.version_number}`, mapDiffSummary(row.diff_summary));
+  }
+  return map;
+}

--- a/src/components/modules/admin/services/roles.service.ts
+++ b/src/components/modules/admin/services/roles.service.ts
@@ -1,0 +1,65 @@
+/**
+ * Role resolution and enforcement for the admin area.
+ *
+ * `requireRole` mirrors `requireAdmin`: it resolves the session first (which
+ * redirects anonymous visitors to the login page) and then asserts the role.
+ * RLS remains the real boundary — this layer exists so an action fails with a
+ * readable message instead of an opaque Postgres error, and so the UI can hide
+ * what the role cannot do.
+ */
+
+import type { AdminSession, EditorialRole, TeamMember } from '@/@types/editorial';
+import { assertRoleAllowed } from '@/lib/editorial/permissions';
+import { createClient } from '@/lib/supabase/server';
+import { requireAdmin } from './auth.service';
+
+export { ForbiddenError } from '@/lib/editorial/permissions';
+
+/** The current session's role, or `null` when nobody is signed in. */
+export async function getCurrentRole(): Promise<EditorialRole | null> {
+  const { getCurrentAdmin } = await import('./auth.service');
+  const admin = await getCurrentAdmin();
+  return admin?.role ?? null;
+}
+
+/**
+ * Require an authenticated admin whose role is one of `allowed`.
+ *
+ * @throws ForbiddenError when the session's role is insufficient.
+ */
+export async function requireRole(...allowed: EditorialRole[]): Promise<AdminSession> {
+  const session = await requireAdmin();
+  assertRoleAllowed(session.role, allowed);
+  return session;
+}
+
+/** The team roster shown on `/admin/team`. Owner-only in practice — RLS
+ *  returns just the caller's own row to anyone else. */
+export async function listTeam(): Promise<TeamMember[]> {
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from('admin_users')
+    .select('email, role, author_id, display_name, created_at, author:authors ( name )')
+    .order('created_at', { ascending: true });
+
+  if (error) throw error;
+
+  type Row = {
+    email: string;
+    role: EditorialRole;
+    author_id: string | null;
+    display_name: string | null;
+    created_at: string;
+    author: { name: string } | null;
+  };
+
+  return ((data ?? []) as unknown as Row[]).map((row) => ({
+    email: row.email,
+    role: row.role,
+    authorId: row.author_id,
+    authorName: row.author?.name ?? null,
+    displayName: row.display_name,
+    createdAt: row.created_at,
+  }));
+}

--- a/src/components/modules/admin/services/scheduling.service.ts
+++ b/src/components/modules/admin/services/scheduling.service.ts
@@ -1,0 +1,232 @@
+/**
+ * Scheduled publishing.
+ *
+ * `publishScheduledArticles()` is the body of the Vercel Cron route
+ * (`/api/cron/publish-scheduled`). It runs with the service-role client so it
+ * can flip rows the signed-in editor is not present for, and it must be
+ * idempotent: two overlapping cron runs must never publish the same article
+ * twice.
+ *
+ * Idempotency comes from the update predicate, not from application state. The
+ * statement is `set status='published' where status='scheduled' and
+ * scheduled_at <= now()`, so under READ COMMITTED a second concurrent run
+ * blocks on the row lock, re-checks the predicate once the first commits, sees
+ * `status='published'`, and skips the row. `.select()` therefore returns only
+ * the rows *this* run actually changed, and that set is what drives the
+ * follow-up work (attestation, revalidation).
+ *
+ * `published_at` and the audit row are stamped by the database trigger
+ * (`enforce_status_transition`), so they are written exactly once per
+ * transition no matter who performs it.
+ *
+ * Dependencies are injected so the cron logic can be tested without Supabase,
+ * Stellar or a Next.js request context.
+ */
+
+import type { CalendarEntry } from '@/@types/editorial';
+import type { TypedSupabaseClient } from '@/lib/supabase';
+
+export interface PublishedArticle {
+  id: string;
+  slug: string;
+}
+
+export interface PublishScheduledResult {
+  publishedCount: number;
+  published: PublishedArticle[];
+  errors: string[];
+}
+
+export interface SchedulingDeps {
+  /** Service-role client — bypasses RLS. */
+  client: TypedSupabaseClient;
+  /** Invalidates a Next.js route cache entry. */
+  revalidate: (path: string) => void;
+  /** Anchors the published article on Stellar. Must never throw. */
+  attest: (article: PublishedArticle) => Promise<void>;
+  now: () => Date;
+}
+
+/**
+ * Publish every article whose scheduled time has arrived.
+ *
+ * Safe to call concurrently; see the module docblock.
+ */
+export async function publishScheduledArticles(
+  overrides: Partial<SchedulingDeps> = {}
+): Promise<PublishScheduledResult> {
+  const deps = await resolveDeps(overrides);
+  const errors: string[] = [];
+
+  const { data, error } = await deps.client
+    .from('news_articles')
+    .update({ status: 'published' })
+    .eq('status', 'scheduled')
+    .lte('scheduled_at', deps.now().toISOString())
+    .select('id, slug');
+
+  if (error) {
+    return { publishedCount: 0, published: [], errors: [error.message] };
+  }
+
+  const published: PublishedArticle[] = (data ?? []).map((row) => ({
+    id: row.id,
+    slug: row.slug,
+  }));
+
+  if (published.length === 0) {
+    return { publishedCount: 0, published: [], errors };
+  }
+
+  // Anchor each article on-chain. Attestation failures are recorded but never
+  // roll back a publication — the article is already live.
+  for (const article of published) {
+    try {
+      await deps.attest(article);
+    } catch (err) {
+      errors.push(
+        `attestation failed for ${article.slug}: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+
+  for (const path of ['/', '/news', ...published.map((a) => `/news/${a.slug}`)]) {
+    try {
+      deps.revalidate(path);
+    } catch (err) {
+      errors.push(
+        `revalidate failed for ${path}: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+
+  return { publishedCount: published.length, published, errors };
+}
+
+/**
+ * Fill in whatever the caller did not supply.
+ *
+ * Each default is imported lazily *and only when missing*: `@/lib/supabase/admin`
+ * pulls in `server-only` and `next/cache` needs a request context, so eagerly
+ * resolving them would make this module unusable from a plain Node test runner
+ * even when the test injects every dependency.
+ */
+async function resolveDeps(overrides: Partial<SchedulingDeps>): Promise<SchedulingDeps> {
+  let client = overrides.client;
+  if (!client) {
+    const { createAdminClient } = await import('@/lib/supabase/admin');
+    client = createAdminClient() as unknown as TypedSupabaseClient;
+  }
+
+  let revalidate = overrides.revalidate;
+  if (!revalidate) {
+    const { revalidatePath } = await import('next/cache');
+    revalidate = (path: string) => revalidatePath(path);
+  }
+
+  let attest = overrides.attest;
+  if (!attest) {
+    const resolvedClient = client;
+    attest = async (article: PublishedArticle) => {
+      const { attestPublishedArticle } = await import('./attestation.service');
+      await attestPublishedArticle(resolvedClient, article);
+    };
+  }
+
+  return { client, revalidate, attest, now: overrides.now ?? (() => new Date()) };
+}
+
+/** Queue an article for automatic publication at `scheduledAt`. */
+export async function schedule(
+  supabase: TypedSupabaseClient,
+  params: { articleId: string; scheduledAt: Date }
+): Promise<void> {
+  if (Number.isNaN(params.scheduledAt.getTime())) {
+    throw new Error('Invalid schedule date.');
+  }
+
+  const { error } = await supabase
+    .from('news_articles')
+    .update({ status: 'scheduled', scheduled_at: params.scheduledAt.toISOString() })
+    .eq('id', params.articleId);
+
+  if (error) throw error;
+}
+
+/** Pull an article back out of the schedule. The database trigger clears
+ *  `scheduled_at` on the way to `draft`. */
+export async function unschedule(
+  supabase: TypedSupabaseClient,
+  params: { articleId: string }
+): Promise<void> {
+  const { error } = await supabase
+    .from('news_articles')
+    .update({ status: 'draft' })
+    .eq('id', params.articleId);
+
+  if (error) throw error;
+}
+
+/** Scheduled and published articles falling inside `[from, to)`, for the calendar. */
+export async function listCalendarEntries(
+  supabase: TypedSupabaseClient,
+  range: { from: Date; to: Date }
+): Promise<CalendarEntry[]> {
+  const fromIso = range.from.toISOString();
+  const toIso = range.to.toISOString();
+
+  const [scheduled, published] = await Promise.all([
+    supabase
+      .from('news_articles')
+      .select('id, title, slug, scheduled_at, author:authors ( name )')
+      .eq('status', 'scheduled')
+      .gte('scheduled_at', fromIso)
+      .lt('scheduled_at', toIso),
+    supabase
+      .from('news_articles')
+      .select('id, title, slug, published_at, author:authors ( name )')
+      .eq('status', 'published')
+      .gte('published_at', fromIso)
+      .lt('published_at', toIso),
+  ]);
+
+  if (scheduled.error) throw scheduled.error;
+  if (published.error) throw published.error;
+
+  type Row = {
+    id: string;
+    title: string;
+    slug: string;
+    scheduled_at?: string | null;
+    published_at?: string | null;
+    author: { name: string } | null;
+  };
+
+  const entries: CalendarEntry[] = [];
+
+  for (const row of (scheduled.data ?? []) as unknown as Row[]) {
+    if (!row.scheduled_at) continue;
+    entries.push({
+      articleId: row.id,
+      title: row.title,
+      slug: row.slug,
+      status: 'scheduled',
+      date: row.scheduled_at,
+      authorName: row.author?.name ?? null,
+    });
+  }
+
+  for (const row of (published.data ?? []) as unknown as Row[]) {
+    if (!row.published_at) continue;
+    entries.push({
+      articleId: row.id,
+      title: row.title,
+      slug: row.slug,
+      status: 'published',
+      date: row.published_at,
+      authorName: row.author?.name ?? null,
+    });
+  }
+
+  return entries.sort((a, b) => a.date.localeCompare(b.date));
+}

--- a/src/components/modules/admin/ui/AdminShell.tsx
+++ b/src/components/modules/admin/ui/AdminShell.tsx
@@ -2,9 +2,13 @@ import Link from 'next/link';
 import { adminLogoutAction } from '@/components/modules/admin/actions';
 import { Button } from '@/components/ui/button';
 import { Container } from '@/layouts';
+import type { EditorialRole } from '@/@types/editorial';
+import { canManageTeam } from '@/lib/editorial/permissions';
+import { RoleBadge } from './RoleBadge';
 
 interface AdminShellProps {
   email: string;
+  role: EditorialRole;
   title: string;
   subtitle?: string;
   children: React.ReactNode;
@@ -14,11 +18,13 @@ const links = [
   { href: '/admin', label: 'Dashboard' },
   { href: '/admin/news', label: 'News' },
   { href: '/admin/news/new', label: 'New article' },
+  { href: '/admin/reviews', label: 'Review queue' },
+  { href: '/admin/calendar', label: 'Calendar' },
   { href: '/admin/monthly-reviews', label: 'Monthly Reviews' },
   { href: '/admin/monthly-reviews/new', label: 'New Review' },
 ] as const;
 
-export function AdminShell({ email, title, subtitle, children }: AdminShellProps) {
+export function AdminShell({ email, role, title, subtitle, children }: AdminShellProps) {
   return (
     <main className="min-h-dvh bg-background pb-16">
       <Container className="grid gap-6 pt-8 md:grid-cols-[220px_1fr]">
@@ -32,9 +38,16 @@ export function AdminShell({ email, title, subtitle, children }: AdminShellProps
                 <Link href={link.href}>{link.label}</Link>
               </Button>
             ))}
+            {/* Owner-only; proxy.ts blocks the route itself for everyone else. */}
+            {canManageTeam(role) ? (
+              <Button asChild variant="ghost" className="w-full justify-start">
+                <Link href="/admin/team">Team</Link>
+              </Button>
+            ) : null}
           </nav>
           <div className="mt-6 border-t pt-4">
             <p className="truncate text-xs text-muted-foreground">{email}</p>
+            <RoleBadge role={role} className="mt-1" />
             <form action={adminLogoutAction} className="mt-2">
               <Button type="submit" variant="outline" className="w-full">
                 Log out

--- a/src/components/modules/admin/ui/EditorialCalendar.tsx
+++ b/src/components/modules/admin/ui/EditorialCalendar.tsx
@@ -1,0 +1,176 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import Link from 'next/link';
+import { rescheduleArticleAction } from '@/components/modules/admin/actions';
+import type { CalendarEntry } from '@/@types/editorial';
+
+interface EditorialCalendarProps {
+  /** Month being displayed, as `YYYY-MM`. */
+  month: string;
+  entries: CalendarEntry[];
+  /** Owners and editors may drag scheduled articles to another day. */
+  canReschedule: boolean;
+}
+
+const WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const;
+
+/**
+ * Month grid of scheduled and published articles.
+ *
+ * Scheduled entries are draggable for owners and editors; dropping one on
+ * another day keeps its time of day and only moves the date.
+ */
+export function EditorialCalendar({ month, entries, canReschedule }: EditorialCalendarProps) {
+  const [dragging, setDragging] = useState<string | null>(null);
+  const [hoveredDay, setHoveredDay] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const { year, monthIndex } = parseMonth(month);
+  const firstOfMonth = new Date(year, monthIndex, 1);
+  const daysInMonth = new Date(year, monthIndex + 1, 0).getDate();
+  const leadingBlanks = firstOfMonth.getDay();
+
+  const byDay = new Map<string, CalendarEntry[]>();
+  for (const entry of entries) {
+    const key = dayKey(new Date(entry.date));
+    const bucket = byDay.get(key);
+    if (bucket) bucket.push(entry);
+    else byDay.set(key, [entry]);
+  }
+
+  function handleDrop(dayIso: string) {
+    const articleId = dragging;
+    setDragging(null);
+    setHoveredDay(null);
+    if (!articleId) return;
+
+    const entry = entries.find((e) => e.articleId === articleId);
+    if (!entry) return;
+
+    // Keep the original time of day; only the date moves.
+    const original = new Date(entry.date);
+    const [y, m, d] = dayIso.split('-').map(Number);
+    const target = new Date(original);
+    target.setFullYear(y, m - 1, d);
+
+    setError(null);
+    startTransition(async () => {
+      try {
+        await rescheduleArticleAction(articleId, target.toISOString());
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Could not reschedule.');
+      }
+    });
+  }
+
+  const cells: (number | null)[] = [
+    ...Array.from({ length: leadingBlanks }, () => null),
+    ...Array.from({ length: daysInMonth }, (_, i) => i + 1),
+  ];
+
+  return (
+    <div className="space-y-3">
+      {error ? (
+        <p className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
+          {error}
+        </p>
+      ) : null}
+
+      <div
+        className={`overflow-hidden rounded-2xl border bg-card ${pending ? 'opacity-60' : ''}`}
+        aria-busy={pending}
+      >
+        <div className="grid grid-cols-7 border-b bg-muted/50 text-xs uppercase tracking-[0.14em] text-muted-foreground">
+          {WEEKDAYS.map((day) => (
+            <div key={day} className="px-2 py-2 text-center">
+              {day}
+            </div>
+          ))}
+        </div>
+
+        <div className="grid grid-cols-7">
+          {cells.map((day, index) => {
+            if (day === null) {
+              return (
+                <div key={`blank-${index}`} className="min-h-24 border-b border-r bg-muted/20" />
+              );
+            }
+
+            const iso = `${year}-${pad(monthIndex + 1)}-${pad(day)}`;
+            const dayEntries = byDay.get(iso) ?? [];
+            const isDropTarget = canReschedule && hoveredDay === iso && dragging !== null;
+
+            return (
+              <div
+                key={iso}
+                className={`min-h-24 space-y-1 border-b border-r p-1.5 ${isDropTarget ? 'bg-blue-50 dark:bg-blue-950/40' : ''}`}
+                onDragOver={
+                  canReschedule
+                    ? (event) => {
+                        event.preventDefault();
+                        setHoveredDay(iso);
+                      }
+                    : undefined
+                }
+                onDragLeave={canReschedule ? () => setHoveredDay(null) : undefined}
+                onDrop={canReschedule ? () => handleDrop(iso) : undefined}
+              >
+                <p className="text-right text-xs text-muted-foreground">{day}</p>
+
+                {dayEntries.map((entry) => {
+                  const draggable = canReschedule && entry.status === 'scheduled';
+                  return (
+                    <div
+                      key={`${entry.articleId}-${entry.status}`}
+                      draggable={draggable}
+                      onDragStart={draggable ? () => setDragging(entry.articleId) : undefined}
+                      onDragEnd={draggable ? () => setDragging(null) : undefined}
+                      className={`rounded-md px-1.5 py-1 text-xs ${
+                        entry.status === 'scheduled'
+                          ? 'bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300'
+                          : 'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300'
+                      } ${draggable ? 'cursor-grab active:cursor-grabbing' : ''}`}
+                      title={`${entry.title} — ${new Date(entry.date).toLocaleString()}`}
+                    >
+                      <Link
+                        href={`/admin/news/${entry.articleId}/edit`}
+                        className="block truncate hover:underline"
+                      >
+                        {entry.title}
+                      </Link>
+                    </div>
+                  );
+                })}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <p className="text-xs text-muted-foreground">
+        {canReschedule
+          ? 'Drag a scheduled article to another day to move it. Published articles are fixed.'
+          : 'Only owners and editors can reschedule articles.'}
+      </p>
+    </div>
+  );
+}
+
+function parseMonth(month: string): { year: number; monthIndex: number } {
+  const [y, m] = month.split('-').map(Number);
+  const now = new Date();
+  if (!Number.isFinite(y) || !Number.isFinite(m) || m < 1 || m > 12) {
+    return { year: now.getFullYear(), monthIndex: now.getMonth() };
+  }
+  return { year: y, monthIndex: m - 1 };
+}
+
+function pad(value: number): string {
+  return String(value).padStart(2, '0');
+}
+
+function dayKey(date: Date): string {
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+}

--- a/src/components/modules/admin/ui/ReviewCommentThread.tsx
+++ b/src/components/modules/admin/ui/ReviewCommentThread.tsx
@@ -1,0 +1,120 @@
+import {
+  approveReviewAction,
+  requestChangesAction,
+  requestReviewAction,
+} from '@/components/modules/admin/actions';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import type { ArticleReviewEvent, ReviewState } from '@/@types/editorial';
+import type { EditorialStatus } from '@/lib/editorial/transitions';
+
+const STATE_LABELS: Record<ReviewState, string> = {
+  requested: 'requested review',
+  approved: 'approved',
+  changes_requested: 'requested changes',
+};
+
+const STATE_STYLES: Record<ReviewState, string> = {
+  requested: 'bg-amber-50 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300',
+  approved: 'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300',
+  changes_requested: 'bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-300',
+};
+
+interface ReviewCommentThreadProps {
+  articleId: string;
+  status: EditorialStatus;
+  events: ArticleReviewEvent[];
+  /** Owners and editors may resolve; everyone else may only submit. */
+  canReview: boolean;
+  canSubmit: boolean;
+}
+
+/**
+ * The append-only review thread for one article.
+ *
+ * Every row in `article_reviews` is an event, so this renders as a timeline
+ * rather than an editable record.
+ */
+export function ReviewCommentThread({
+  articleId,
+  status,
+  events,
+  canReview,
+  canSubmit,
+}: ReviewCommentThreadProps) {
+  const isOpen = events.length > 0 && events[events.length - 1].state === 'requested';
+  const canRequestReview = canSubmit && (status === 'draft' || status === 'in_review') && !isOpen;
+
+  return (
+    <div className="rounded-2xl border bg-card p-4">
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Review</p>
+        {isOpen ? (
+          <span className="inline-flex items-center rounded-full bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-300">
+            open
+          </span>
+        ) : null}
+      </div>
+
+      {events.length === 0 ? (
+        <p className="mt-3 text-xs text-muted-foreground">No review activity yet.</p>
+      ) : (
+        <ol className="mt-3 space-y-3">
+          {events.map((event) => (
+            <li key={event.id} className="border-l-2 border-muted pl-3">
+              <div className="flex flex-wrap items-center gap-1.5 text-xs">
+                <span
+                  className={`inline-flex items-center rounded-full px-2 py-0.5 font-medium ${STATE_STYLES[event.state]}`}
+                >
+                  {STATE_LABELS[event.state]}
+                </span>
+                <span className="text-muted-foreground">{event.requestedBy}</span>
+                {event.versionNumber !== null ? (
+                  <span className="font-mono text-muted-foreground">v{event.versionNumber}</span>
+                ) : null}
+              </div>
+              {event.comment ? <p className="mt-1 text-sm">{event.comment}</p> : null}
+              <p className="mt-1 text-xs text-muted-foreground">
+                {new Date(event.createdAt).toLocaleString()}
+              </p>
+            </li>
+          ))}
+        </ol>
+      )}
+
+      {canRequestReview ? (
+        <form action={requestReviewAction} className="mt-4 space-y-2">
+          <input type="hidden" name="articleId" value={articleId} />
+          <Textarea name="comment" placeholder="Anything the reviewer should know?" rows={2} />
+          <Button type="submit" size="sm" variant="outline" className="w-full">
+            Submit for review
+          </Button>
+        </form>
+      ) : null}
+
+      {canReview && isOpen ? (
+        <div className="mt-4 space-y-2 border-t pt-4">
+          <form action={approveReviewAction} className="space-y-2">
+            <input type="hidden" name="articleId" value={articleId} />
+            <Textarea name="comment" placeholder="Approval note (optional)" rows={2} />
+            <Button type="submit" size="sm" className="w-full">
+              Approve
+            </Button>
+          </form>
+          <form action={requestChangesAction} className="space-y-2">
+            <input type="hidden" name="articleId" value={articleId} />
+            <Textarea
+              name="comment"
+              placeholder="What needs to change? (required)"
+              rows={2}
+              required
+            />
+            <Button type="submit" size="sm" variant="outline" className="w-full">
+              Request changes
+            </Button>
+          </form>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/modules/admin/ui/ReviewQueue.tsx
+++ b/src/components/modules/admin/ui/ReviewQueue.tsx
@@ -1,0 +1,87 @@
+import Link from 'next/link';
+import { approveReviewAction, requestChangesAction } from '@/components/modules/admin/actions';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { VersionDiffBadge } from '@/components/modules/news/ui/VersionDiffBadge';
+import type { OpenReviewItem } from '@/@types/editorial';
+
+interface ReviewQueueProps {
+  items: OpenReviewItem[];
+  /** Owners and editors get the approve / request-changes controls. */
+  canReview: boolean;
+}
+
+/** Open reviews with article, requester, age and the version diff badge. */
+export function ReviewQueue({ items, canReview }: ReviewQueueProps) {
+  if (items.length === 0) {
+    return (
+      <div className="rounded-2xl border bg-card px-4 py-10 text-center">
+        <p className="text-sm text-muted-foreground">Nothing waiting for review.</p>
+      </div>
+    );
+  }
+
+  return (
+    <ul className="space-y-3">
+      {items.map((item) => (
+        <li key={item.articleId} className="rounded-2xl border bg-card p-4">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="min-w-0 space-y-1">
+              <Link
+                href={`/admin/news/${item.articleId}/edit`}
+                className="font-medium hover:underline"
+              >
+                {item.articleTitle}
+              </Link>
+              <p className="text-xs text-muted-foreground">
+                /{item.articleSlug} · requested by {item.requestedBy} ·{' '}
+                {formatAge(item.requestedAt)}
+                {item.versionNumber !== null ? ` · v${item.versionNumber}` : ''}
+              </p>
+              <VersionDiffBadge diffSummary={item.diffSummary} />
+              {item.comment ? <p className="pt-1 text-sm">{item.comment}</p> : null}
+            </div>
+
+            <Button asChild size="sm" variant="outline">
+              <Link href={`/admin/news/${item.articleId}/edit`}>Open</Link>
+            </Button>
+          </div>
+
+          {canReview ? (
+            <div className="mt-4 grid gap-2 border-t pt-4 sm:grid-cols-2">
+              <form action={approveReviewAction} className="flex gap-2">
+                <input type="hidden" name="articleId" value={item.articleId} />
+                <Input name="comment" placeholder="Approval note (optional)" />
+                <Button type="submit" size="sm">
+                  Approve
+                </Button>
+              </form>
+              <form action={requestChangesAction} className="flex gap-2">
+                <input type="hidden" name="articleId" value={item.articleId} />
+                <Input name="comment" placeholder="What needs changing?" required />
+                <Button type="submit" size="sm" variant="outline">
+                  Request changes
+                </Button>
+              </form>
+            </div>
+          ) : null}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function formatAge(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  if (!Number.isFinite(ms) || ms < 0) return 'just now';
+
+  const minutes = Math.floor(ms / 60_000);
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}

--- a/src/components/modules/admin/ui/RoleBadge.tsx
+++ b/src/components/modules/admin/ui/RoleBadge.tsx
@@ -1,0 +1,23 @@
+import type { EditorialRole } from '@/@types/editorial';
+
+const ROLE_STYLES: Record<EditorialRole, string> = {
+  owner: 'bg-purple-50 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300',
+  editor: 'bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300',
+  author: 'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300',
+  contributor: 'bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300',
+};
+
+interface RoleBadgeProps {
+  role: EditorialRole;
+  className?: string;
+}
+
+export function RoleBadge({ role, className }: RoleBadgeProps) {
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${ROLE_STYLES[role]} ${className ?? ''}`}
+    >
+      {role}
+    </span>
+  );
+}

--- a/src/components/modules/admin/ui/SchedulePicker.tsx
+++ b/src/components/modules/admin/ui/SchedulePicker.tsx
@@ -1,0 +1,67 @@
+import { scheduleArticleAction, unscheduleArticleAction } from '@/components/modules/admin/actions';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import type { EditorialStatus } from '@/lib/editorial/transitions';
+
+interface SchedulePickerProps {
+  articleId: string;
+  status: EditorialStatus;
+  scheduledAt: string | null;
+  /** Owners and editors only; hidden entirely for other roles. */
+  canSchedule: boolean;
+}
+
+/** Datetime input that queues an article for the publishing cron. */
+export function SchedulePicker({
+  articleId,
+  status,
+  scheduledAt,
+  canSchedule,
+}: SchedulePickerProps) {
+  if (!canSchedule) return null;
+
+  const isScheduled = status === 'scheduled';
+  const defaultValue = scheduledAt ? toLocalInputValue(scheduledAt) : '';
+
+  return (
+    <div className="rounded-2xl border bg-card p-4">
+      <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Schedule</p>
+
+      {isScheduled && scheduledAt ? (
+        <p className="mt-2 text-sm">
+          Publishes automatically on{' '}
+          <span className="font-medium">{new Date(scheduledAt).toLocaleString()}</span>.
+        </p>
+      ) : (
+        <p className="mt-2 text-xs text-muted-foreground">
+          Pick a future date and the publishing cron takes it live within 10 minutes.
+        </p>
+      )}
+
+      <form action={scheduleArticleAction} className="mt-3 space-y-2">
+        <input type="hidden" name="articleId" value={articleId} />
+        <Input type="datetime-local" name="scheduledAt" required defaultValue={defaultValue} />
+        <Button type="submit" size="sm" variant="outline" className="w-full">
+          {isScheduled ? 'Reschedule' : 'Schedule'}
+        </Button>
+      </form>
+
+      {isScheduled ? (
+        <form action={unscheduleArticleAction} className="mt-2">
+          <input type="hidden" name="articleId" value={articleId} />
+          <Button type="submit" size="sm" variant="ghost" className="w-full">
+            Cancel schedule
+          </Button>
+        </form>
+      ) : null}
+    </div>
+  );
+}
+
+/** `datetime-local` needs `YYYY-MM-DDTHH:mm` in local time, not a UTC ISO string. */
+function toLocalInputValue(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '';
+  const offsetMs = date.getTimezoneOffset() * 60_000;
+  return new Date(date.getTime() - offsetMs).toISOString().slice(0, 16);
+}

--- a/src/components/modules/admin/ui/StatusBadge.tsx
+++ b/src/components/modules/admin/ui/StatusBadge.tsx
@@ -1,0 +1,24 @@
+import { statusLabel, type EditorialStatus } from '@/lib/editorial/transitions';
+
+const STATUS_STYLES: Record<EditorialStatus, string> = {
+  draft: 'bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300',
+  in_review: 'bg-amber-50 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300',
+  scheduled: 'bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300',
+  published: 'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300',
+  archived: 'bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-300',
+};
+
+interface StatusBadgeProps {
+  status: EditorialStatus;
+  className?: string;
+}
+
+export function StatusBadge({ status, className }: StatusBadgeProps) {
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_STYLES[status]} ${className ?? ''}`}
+    >
+      {statusLabel(status)}
+    </span>
+  );
+}

--- a/src/components/modules/admin/ui/StatusTransitionMenu.tsx
+++ b/src/components/modules/admin/ui/StatusTransitionMenu.tsx
@@ -1,0 +1,74 @@
+import { transitionArticleStatusAction } from '@/components/modules/admin/actions';
+import { Button } from '@/components/ui/button';
+import type { EditorialRole } from '@/@types/editorial';
+import {
+  allowedTransitionsForRole,
+  statusLabel,
+  type EditorialStatus,
+} from '@/lib/editorial/transitions';
+import { StatusBadge } from './StatusBadge';
+
+interface StatusTransitionMenuProps {
+  articleId: string;
+  status: EditorialStatus;
+  role: EditorialRole;
+}
+
+/**
+ * Replaces the old free-form status select.
+ *
+ * Offers only the moves that are legal from the current status *and* permitted
+ * for the current role, so the editor never sees a button that would be
+ * rejected by the database.
+ */
+export function StatusTransitionMenu({ articleId, status, role }: StatusTransitionMenuProps) {
+  const targets = allowedTransitionsForRole(status, role);
+
+  return (
+    <div className="rounded-2xl border bg-card p-4">
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Status</p>
+        <StatusBadge status={status} />
+      </div>
+
+      {targets.length === 0 ? (
+        <p className="mt-3 text-xs text-muted-foreground">
+          No transitions available for your role from “{statusLabel(status)}”.
+        </p>
+      ) : (
+        <div className="mt-3 flex flex-wrap gap-2">
+          {targets.map((target) => (
+            <form key={target} action={transitionArticleStatusAction}>
+              <input type="hidden" name="articleId" value={articleId} />
+              <input type="hidden" name="toStatus" value={target} />
+              <Button
+                type="submit"
+                size="sm"
+                variant={target === 'published' ? 'default' : 'outline'}
+              >
+                {labelFor(target)}
+              </Button>
+            </form>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function labelFor(target: EditorialStatus): string {
+  switch (target) {
+    case 'in_review':
+      return 'Submit for review';
+    case 'published':
+      return 'Publish now';
+    case 'draft':
+      return 'Back to draft';
+    case 'archived':
+      return 'Archive';
+    case 'scheduled':
+      return 'Mark scheduled';
+    default:
+      return statusLabel(target);
+  }
+}

--- a/src/lib/editorial/__tests__/permissions.test.ts
+++ b/src/lib/editorial/__tests__/permissions.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import type { EditorialRole } from '@/@types/editorial';
+import {
+  assertRoleAllowed,
+  canDeleteArticles,
+  canEditArticle,
+  canManageTeam,
+  canPublish,
+  canReview,
+  canSeeAllArticles,
+  EDITORIAL_ROLES,
+  ForbiddenError,
+  isEditorialRole,
+} from '../permissions';
+import { EDITORIAL_STATUSES } from '../transitions';
+
+const ALL_ROLES = [...EDITORIAL_ROLES];
+
+describe('role capabilities', () => {
+  it('lets only owners and editors publish', () => {
+    expect(ALL_ROLES.filter(canPublish)).toEqual(['owner', 'editor']);
+  });
+
+  it('lets only owners manage the team', () => {
+    expect(ALL_ROLES.filter(canManageTeam)).toEqual(['owner']);
+  });
+
+  it('lets only owners delete articles', () => {
+    expect(ALL_ROLES.filter(canDeleteArticles)).toEqual(['owner']);
+  });
+
+  it('ties review resolution to publishing rights', () => {
+    for (const role of ALL_ROLES) {
+      expect(canReview(role)).toBe(canPublish(role));
+    }
+  });
+
+  it('hides other authors work from contributors only', () => {
+    expect(ALL_ROLES.filter((role) => !canSeeAllArticles(role))).toEqual(['contributor']);
+  });
+
+  it('recognises exactly the four roles', () => {
+    for (const role of ALL_ROLES) expect(isEditorialRole(role)).toBe(true);
+    for (const other of ['admin', 'reader', '', 'OWNER']) {
+      expect(isEditorialRole(other)).toBe(false);
+    }
+  });
+});
+
+describe('canEditArticle', () => {
+  it('lets owners and editors edit anything, owned or not, at any status', () => {
+    for (const role of ['owner', 'editor'] as EditorialRole[]) {
+      for (const status of EDITORIAL_STATUSES) {
+        expect(canEditArticle(role, { ownsArticle: false, status })).toBe(true);
+        expect(canEditArticle(role, { ownsArticle: true, status })).toBe(true);
+      }
+    }
+  });
+
+  it('refuses authors and contributors on articles they do not own', () => {
+    for (const role of ['author', 'contributor'] as EditorialRole[]) {
+      for (const status of EDITORIAL_STATUSES) {
+        expect(canEditArticle(role, { ownsArticle: false, status })).toBe(false);
+      }
+    }
+  });
+
+  it('lets an author edit their own article at any status', () => {
+    for (const status of EDITORIAL_STATUSES) {
+      expect(canEditArticle('author', { ownsArticle: true, status })).toBe(true);
+    }
+  });
+
+  it('limits a contributor to their own draft or in-review article', () => {
+    expect(canEditArticle('contributor', { ownsArticle: true, status: 'draft' })).toBe(true);
+    expect(canEditArticle('contributor', { ownsArticle: true, status: 'in_review' })).toBe(true);
+    expect(canEditArticle('contributor', { ownsArticle: true, status: 'scheduled' })).toBe(false);
+    expect(canEditArticle('contributor', { ownsArticle: true, status: 'published' })).toBe(false);
+    expect(canEditArticle('contributor', { ownsArticle: true, status: 'archived' })).toBe(false);
+  });
+});
+
+describe('assertRoleAllowed', () => {
+  it('passes when the role is listed', () => {
+    expect(() => assertRoleAllowed('editor', ['owner', 'editor'])).not.toThrow();
+  });
+
+  it('rejects each insufficient role with a ForbiddenError', () => {
+    for (const role of ['author', 'contributor'] as EditorialRole[]) {
+      expect(() => assertRoleAllowed(role, ['owner', 'editor'])).toThrow(ForbiddenError);
+      expect(() => assertRoleAllowed(role, ['owner', 'editor'])).toThrow(
+        `role ${role} cannot perform this action`
+      );
+    }
+  });
+
+  it('rejects every non-owner for an owner-only action', () => {
+    for (const role of ALL_ROLES) {
+      if (role === 'owner') continue;
+      expect(() => assertRoleAllowed(role, ['owner'])).toThrow(ForbiddenError);
+    }
+  });
+
+  it('carries a 403 status', () => {
+    try {
+      assertRoleAllowed('contributor', ['owner']);
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ForbiddenError);
+      expect((err as ForbiddenError).status).toBe(403);
+    }
+  });
+});

--- a/src/lib/editorial/__tests__/transitions.test.ts
+++ b/src/lib/editorial/__tests__/transitions.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import type { EditorialRole } from '@/@types/editorial';
+import {
+  allowedTransitions,
+  allowedTransitionsForRole,
+  canTransition,
+  EDITORIAL_STATUSES,
+  isPublishingStatus,
+  isValidTransition,
+  statusLabel,
+  type EditorialStatus,
+} from '../transitions';
+
+/**
+ * The full transition matrix, written out independently of the implementation.
+ *
+ * This is the same table encoded in `public.enforce_status_transition()` in
+ * `supabase/migrations/0006_editorial_workflow.sql`. Asserting every ordered
+ * pair — allowed *and* forbidden — means a change on either side that is not
+ * mirrored on the other shows up as a failure here.
+ */
+const EXPECTED: Record<EditorialStatus, EditorialStatus[]> = {
+  draft: ['in_review', 'scheduled', 'published', 'archived'],
+  in_review: ['draft', 'scheduled', 'published'],
+  scheduled: ['draft', 'published', 'archived'],
+  published: ['archived', 'draft'],
+  archived: ['draft'],
+};
+
+const ALL_ROLES: EditorialRole[] = ['owner', 'editor', 'author', 'contributor'];
+const PUBLISHERS: EditorialRole[] = ['owner', 'editor'];
+
+describe('transition matrix', () => {
+  it('covers every status', () => {
+    expect([...EDITORIAL_STATUSES].sort()).toEqual(Object.keys(EXPECTED).sort());
+  });
+
+  // Every ordered pair, allowed and forbidden.
+  for (const from of EDITORIAL_STATUSES) {
+    for (const to of EDITORIAL_STATUSES) {
+      const shouldBeValid = EXPECTED[from].includes(to);
+
+      it(`${shouldBeValid ? 'allows' : 'rejects'} ${from} -> ${to}`, () => {
+        expect(isValidTransition(from, to)).toBe(shouldBeValid);
+      });
+    }
+  }
+
+  it('never lists a status as a transition to itself', () => {
+    for (const status of EDITORIAL_STATUSES) {
+      expect(allowedTransitions(status)).not.toContain(status);
+    }
+  });
+
+  it('treats published and scheduled as the publishing statuses', () => {
+    expect(EDITORIAL_STATUSES.filter(isPublishingStatus)).toEqual(['scheduled', 'published']);
+  });
+
+  it('makes every status reachable from draft or via draft', () => {
+    // draft is the hub: everything can get back to it, and it reaches the rest.
+    for (const status of EDITORIAL_STATUSES) {
+      if (status === 'draft') continue;
+      expect(allowedTransitions(status)).toContain('draft');
+    }
+  });
+
+  it('labels every status', () => {
+    for (const status of EDITORIAL_STATUSES) {
+      expect(statusLabel(status)).toBeTruthy();
+      expect(statusLabel(status)).not.toBe(status);
+    }
+  });
+});
+
+describe('transitions by role', () => {
+  for (const from of EDITORIAL_STATUSES) {
+    for (const to of EDITORIAL_STATUSES) {
+      for (const role of ALL_ROLES) {
+        const structurallyValid = EXPECTED[from].includes(to);
+        const roleAllows = PUBLISHERS.includes(role) || !isPublishingStatus(to);
+        const expected = structurallyValid && roleAllows;
+
+        it(`${role}: ${expected ? 'allows' : 'rejects'} ${from} -> ${to}`, () => {
+          expect(canTransition(from, to, role)).toBe(expected);
+        });
+      }
+    }
+  }
+
+  it('never offers publish or schedule to authors and contributors', () => {
+    for (const role of ['author', 'contributor'] as EditorialRole[]) {
+      for (const from of EDITORIAL_STATUSES) {
+        const targets = allowedTransitionsForRole(from, role);
+        expect(targets).not.toContain('published');
+        expect(targets).not.toContain('scheduled');
+      }
+    }
+  });
+
+  it('gives owners and editors the unrestricted matrix', () => {
+    for (const role of PUBLISHERS) {
+      for (const from of EDITORIAL_STATUSES) {
+        expect([...allowedTransitionsForRole(from, role)]).toEqual([...allowedTransitions(from)]);
+      }
+    }
+  });
+
+  it('still lets an author submit for review and archive', () => {
+    expect(allowedTransitionsForRole('draft', 'author')).toEqual(['in_review', 'archived']);
+    expect(allowedTransitionsForRole('draft', 'contributor')).toEqual(['in_review', 'archived']);
+  });
+});

--- a/src/lib/editorial/permissions.ts
+++ b/src/lib/editorial/permissions.ts
@@ -1,0 +1,82 @@
+/**
+ * Role capabilities.
+ *
+ * The authoritative boundary is RLS (see `0006_editorial_workflow.sql`); this
+ * module exists so the UI can hide what a role cannot do and so server actions
+ * can fail fast with a clear message instead of surfacing a Postgres error.
+ *
+ * Pure module — safe to import from Client Components and from Node tests.
+ */
+
+import type { EditorialRole } from '@/@types/editorial';
+import type { EditorialStatus } from './transitions';
+
+export const EDITORIAL_ROLES: readonly EditorialRole[] = [
+  'owner',
+  'editor',
+  'author',
+  'contributor',
+] as const;
+
+export function isEditorialRole(value: string): value is EditorialRole {
+  return (EDITORIAL_ROLES as readonly string[]).includes(value);
+}
+
+/** Thrown when a session's role is insufficient for the attempted action. */
+export class ForbiddenError extends Error {
+  readonly status = 403;
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'ForbiddenError';
+  }
+}
+
+/** Owners and editors may publish, schedule and resolve reviews. */
+export function canPublish(role: EditorialRole): boolean {
+  return role === 'owner' || role === 'editor';
+}
+
+/** Only owners manage the team roster and roles. */
+export function canManageTeam(role: EditorialRole): boolean {
+  return role === 'owner';
+}
+
+/** Only owners delete articles outright; everyone else archives. */
+export function canDeleteArticles(role: EditorialRole): boolean {
+  return role === 'owner';
+}
+
+/** Owners and editors resolve reviews (approve / request changes). */
+export function canReview(role: EditorialRole): boolean {
+  return canPublish(role);
+}
+
+/** Contributors only ever see their own articles. */
+export function canSeeAllArticles(role: EditorialRole): boolean {
+  return role !== 'contributor';
+}
+
+/**
+ * Whether `role` may edit an article it does or does not own.
+ *
+ * Mirrors the `editorial update articles` policy: owners and editors edit
+ * anything; authors edit their own at any status; contributors edit their own
+ * only while it is still a draft or in review.
+ */
+export function canEditArticle(
+  role: EditorialRole,
+  options: { ownsArticle: boolean; status: EditorialStatus }
+): boolean {
+  if (canPublish(role)) return true;
+  if (!options.ownsArticle) return false;
+  if (role === 'author') return true;
+  return options.status === 'draft' || options.status === 'in_review';
+}
+
+/** Assert that `role` is one of `allowed`, or throw `ForbiddenError`. */
+export function assertRoleAllowed(role: EditorialRole, allowed: readonly EditorialRole[]): void {
+  if (!allowed.includes(role)) {
+    throw new ForbiddenError(`role ${role} cannot perform this action`);
+  }
+}

--- a/src/lib/editorial/transitions.ts
+++ b/src/lib/editorial/transitions.ts
@@ -1,0 +1,86 @@
+/**
+ * Article status transitions.
+ *
+ * This module is a mirror of `public.enforce_status_transition()` in
+ * `supabase/migrations/0006_editorial_workflow.sql`. The database is the real
+ * boundary — it rejects an invalid change even when the REST API is called
+ * directly — and this table exists so the UI can offer only the moves that
+ * will actually succeed.
+ *
+ * Keep the two in sync: `transitions.test.ts` asserts the full matrix, so a
+ * change here without a matching change in the migration will be caught by a
+ * failing expectation rather than silently diverging.
+ *
+ * Pure module — no Supabase, no server imports, safe to use from a Client
+ * Component and from Node tests.
+ */
+
+import type { EditorialRole } from '@/@types/editorial';
+
+export type EditorialStatus = 'draft' | 'in_review' | 'scheduled' | 'published' | 'archived';
+
+export const EDITORIAL_STATUSES: readonly EditorialStatus[] = [
+  'draft',
+  'in_review',
+  'scheduled',
+  'published',
+  'archived',
+] as const;
+
+/** Statuses only an owner or editor may move an article into. */
+export const PUBLISHING_STATUSES: readonly EditorialStatus[] = ['published', 'scheduled'] as const;
+
+const TRANSITIONS: Record<EditorialStatus, readonly EditorialStatus[]> = {
+  draft: ['in_review', 'scheduled', 'published', 'archived'],
+  in_review: ['draft', 'scheduled', 'published'],
+  scheduled: ['draft', 'published', 'archived'],
+  published: ['archived', 'draft'],
+  archived: ['draft'],
+};
+
+/** Every status reachable from `from`, ignoring who is asking. */
+export function allowedTransitions(from: EditorialStatus): readonly EditorialStatus[] {
+  return TRANSITIONS[from] ?? [];
+}
+
+export function isValidTransition(from: EditorialStatus, to: EditorialStatus): boolean {
+  return allowedTransitions(from).includes(to);
+}
+
+export function isPublishingStatus(status: EditorialStatus): boolean {
+  return PUBLISHING_STATUSES.includes(status);
+}
+
+/**
+ * The transitions a given role may perform from `from`.
+ *
+ * A same-status "transition" is never offered: the guard short-circuits on
+ * `old.status = new.status`, so it is a no-op rather than an error.
+ */
+export function allowedTransitionsForRole(
+  from: EditorialStatus,
+  role: EditorialRole
+): readonly EditorialStatus[] {
+  const canPublish = role === 'owner' || role === 'editor';
+  return allowedTransitions(from).filter((to) => canPublish || !isPublishingStatus(to));
+}
+
+export function canTransition(
+  from: EditorialStatus,
+  to: EditorialStatus,
+  role: EditorialRole
+): boolean {
+  return allowedTransitionsForRole(from, role).includes(to);
+}
+
+const STATUS_LABELS: Record<EditorialStatus, string> = {
+  draft: 'Draft',
+  in_review: 'In review',
+  scheduled: 'Scheduled',
+  published: 'Published',
+  archived: 'Archived',
+};
+
+export function statusLabel(status: EditorialStatus): string {
+  return STATUS_LABELS[status] ?? status;
+}

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -90,12 +90,110 @@ export interface Database {
       admin_users: {
         Row: {
           email: string;
+          created_at: string;
+          role: Database['public']['Enums']['editorial_role'];
+          author_id: string | null;
+          display_name: string | null;
         };
         Insert: {
           email: string;
+          created_at?: string;
+          role?: Database['public']['Enums']['editorial_role'];
+          author_id?: string | null;
+          display_name?: string | null;
         };
         Update: {
           email?: string;
+          created_at?: string;
+          role?: Database['public']['Enums']['editorial_role'];
+          author_id?: string | null;
+          display_name?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'admin_users_author_id_fkey';
+            columns: ['author_id'];
+            referencedRelation: 'authors';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      article_reviews: {
+        Row: {
+          id: string;
+          article_id: string;
+          version_number: number | null;
+          state: Database['public']['Enums']['review_state'];
+          requested_by: string;
+          reviewer_email: string | null;
+          comment: string | null;
+          created_at: string;
+          resolved_at: string | null;
+        };
+        Insert: {
+          id?: string;
+          article_id: string;
+          version_number?: number | null;
+          state?: Database['public']['Enums']['review_state'];
+          requested_by: string;
+          reviewer_email?: string | null;
+          comment?: string | null;
+          created_at?: string;
+          resolved_at?: string | null;
+        };
+        Update: {
+          id?: string;
+          article_id?: string;
+          version_number?: number | null;
+          state?: Database['public']['Enums']['review_state'];
+          requested_by?: string;
+          reviewer_email?: string | null;
+          comment?: string | null;
+          created_at?: string;
+          resolved_at?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'article_reviews_article_id_fkey';
+            columns: ['article_id'];
+            referencedRelation: 'news_articles';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      editorial_audit_log: {
+        Row: {
+          id: string;
+          actor_email: string;
+          action: string;
+          entity: string;
+          entity_id: string | null;
+          from_status: string | null;
+          to_status: string | null;
+          metadata: Json;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          actor_email: string;
+          action: string;
+          entity: string;
+          entity_id?: string | null;
+          from_status?: string | null;
+          to_status?: string | null;
+          metadata?: Json;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          actor_email?: string;
+          action?: string;
+          entity?: string;
+          entity_id?: string | null;
+          from_status?: string | null;
+          to_status?: string | null;
+          metadata?: Json;
+          created_at?: string;
         };
         Relationships: [];
       };
@@ -165,6 +263,7 @@ export interface Database {
           status: Database['public']['Enums']['news_status'];
           reading_time_minutes: number;
           published_at: string | null;
+          scheduled_at: string | null;
           created_at: string;
           updated_at: string;
           author_id: string;
@@ -180,6 +279,7 @@ export interface Database {
           status: Database['public']['Enums']['news_status'];
           reading_time_minutes?: number;
           published_at?: string | null;
+          scheduled_at?: string | null;
           created_at?: string;
           updated_at?: string;
           author_id: string;
@@ -195,6 +295,7 @@ export interface Database {
           status?: Database['public']['Enums']['news_status'];
           reading_time_minutes?: number;
           published_at?: string | null;
+          scheduled_at?: string | null;
           created_at?: string;
           updated_at?: string;
           author_id?: string;
@@ -449,10 +550,24 @@ export interface Database {
         Args: { p_article_id: string };
         Returns: string | null;
       };
+      current_editorial_role: {
+        Args: Record<PropertyKey, never>;
+        Returns: Database['public']['Enums']['editorial_role'] | null;
+      };
+      can_publish: {
+        Args: Record<PropertyKey, never>;
+        Returns: boolean;
+      };
+      owns_article: {
+        Args: { target_article: string };
+        Returns: boolean;
+      };
     };
     Enums: {
-      news_status: 'draft' | 'published' | 'archived';
+      news_status: 'draft' | 'in_review' | 'scheduled' | 'published' | 'archived';
       news_category: 'announcement' | 'product' | 'ecosystem' | 'engineering' | 'community';
+      editorial_role: 'owner' | 'editor' | 'author' | 'contributor';
+      review_state: 'requested' | 'approved' | 'changes_requested';
     };
     CompositeTypes: Record<string, never>;
   };

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -43,12 +43,19 @@ export async function proxy(request: NextRequest) {
 
     const { data: adminUser } = await supabase
       .from('admin_users')
-      .select('email')
+      .select('email, role')
       .eq('email', user.email.toLowerCase())
       .maybeSingle();
 
     if (!adminUser) {
       return NextResponse.redirect(new URL('/admin/login', request.url));
+    }
+
+    // Team management is owner-only. The page re-checks with `requireRole` and
+    // RLS refuses the write regardless — this just avoids showing a screen the
+    // visitor cannot use.
+    if (pathname.startsWith('/admin/team') && adminUser.role !== 'owner') {
+      return NextResponse.redirect(new URL('/admin', request.url));
     }
   }
 

--- a/supabase/migrations/0006_editorial_workflow.sql
+++ b/supabase/migrations/0006_editorial_workflow.sql
@@ -1,0 +1,507 @@
+-- =============================================================================
+-- ACTA News — editorial workflow
+--
+-- Turns the single email allowlist into a real editorial tool:
+--   • four roles (owner / editor / author / contributor) enforced by RLS
+--   • two new statuses (in_review, scheduled) + a transition guard
+--   • an append-only review queue tied to article_versions
+--   • an append-only audit log written by triggers
+--   • scheduled_at + partial index driving the publishing cron
+--
+-- Scheduling note (mirrors supabase/config.toml for collect-ecosystem-metrics):
+--   Scheduled publishing is driven by a Vercel Cron hitting
+--   /api/cron/publish-scheduled every 10 minutes, so the job can reuse the
+--   existing TypeScript services (attestation, versioning, revalidation).
+--   The pg_cron alternative, if you ever want the database to own it:
+--
+--     select cron.schedule(
+--       'publish-scheduled-articles',
+--       '*/10 * * * *',
+--       $$ update public.news_articles
+--            set status = 'published'
+--          where status = 'scheduled'
+--            and scheduled_at <= now() $$
+--     );
+--
+--   That variant publishes correctly (the trigger below still stamps
+--   published_at and writes the audit row) but skips attestation and Next.js
+--   cache revalidation, so the route handler stays the default.
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Roles
+-- ---------------------------------------------------------------------------
+do $$ begin
+  create type public.editorial_role as enum ('owner', 'editor', 'author', 'contributor');
+exception when duplicate_object then null; end $$;
+
+alter table public.admin_users
+  add column if not exists role public.editorial_role not null default 'editor',
+  add column if not exists author_id uuid references public.authors(id) on delete set null,
+  add column if not exists display_name text;
+
+create index if not exists admin_users_author_id_idx
+  on public.admin_users (author_id);
+
+-- Bootstrap: every existing admin becomes an 'editor' by default, which would
+-- leave nobody able to manage the team. Promote the oldest admin row to owner
+-- when no owner exists yet.
+update public.admin_users
+set role = 'owner'
+where email = (
+  select email from public.admin_users order by created_at asc, email asc limit 1
+)
+and not exists (select 1 from public.admin_users where role = 'owner');
+
+-- ---------------------------------------------------------------------------
+-- 2. Helper functions (same pattern as public.is_admin())
+-- ---------------------------------------------------------------------------
+create or replace function public.current_editorial_role()
+returns public.editorial_role
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select au.role
+  from public.admin_users au
+  where lower(au.email) = lower(auth.email());
+$$;
+
+create or replace function public.can_publish()
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select public.current_editorial_role() in ('owner', 'editor');
+$$;
+
+create or replace function public.owns_article(target_article uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from public.news_articles a
+    join public.admin_users au on au.author_id = a.author_id
+    where a.id = target_article
+      and lower(au.email) = lower(auth.email())
+  );
+$$;
+
+-- The JWT `role` claim, or null when the statement runs without a JWT
+-- (migrations, seeds, psql). Wrapped in plpgsql so a malformed claims blob
+-- degrades to null instead of aborting the statement.
+create or replace function public.current_jwt_role()
+returns text
+language plpgsql
+stable
+as $$
+declare
+  v_role text;
+begin
+  begin
+    v_role := nullif(current_setting('request.jwt.claims', true), '')::json->>'role';
+  exception when others then
+    v_role := null;
+  end;
+  return v_role;
+end;
+$$;
+
+-- True for trusted server-side callers: the service-role client used by the
+-- publishing cron, and direct SQL with no JWT at all. Used only to exempt those
+-- callers from the *role* check in the transition guard — the transition matrix
+-- itself still applies to them.
+create or replace function public.is_backend_context()
+returns boolean
+language sql
+stable
+as $$
+  select coalesce(public.current_jwt_role(), 'service_role') = 'service_role';
+$$;
+
+grant execute on function public.current_editorial_role() to authenticated;
+grant execute on function public.can_publish() to authenticated;
+grant execute on function public.owns_article(uuid) to authenticated;
+grant execute on function public.current_jwt_role() to authenticated;
+grant execute on function public.is_backend_context() to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 3. Status enum: draft | in_review | scheduled | published | archived
+--
+-- `alter type ... add value` cannot be followed by a use of the new value in
+-- the same transaction (and Supabase migrations run in one), so the type is
+-- swapped wholesale instead.
+--
+-- Postgres refuses to retype a column that a policy depends on
+-- ("cannot alter type of a column used in a policy definition"), so the three
+-- policies that reference news_articles.status are dropped first and recreated
+-- verbatim below. They are found with:
+--   select p.polname from pg_depend d
+--     join pg_policy p on p.oid = d.objid and d.classid = 'pg_policy'::regclass
+--    where d.refobjid = 'public.news_articles'::regclass
+--      and d.refobjsubid = (select attnum from pg_attribute
+--                            where attrelid = 'public.news_articles'::regclass
+--                              and attname = 'status');
+-- ---------------------------------------------------------------------------
+drop policy if exists "published articles are readable by everyone" on public.news_articles;
+drop policy if exists "article tags are readable by everyone" on public.news_article_tags;
+drop policy if exists "published article versions are readable by everyone" on public.article_versions;
+
+alter table public.news_articles alter column status drop default;
+
+create type public.news_status_new as enum
+  ('draft', 'in_review', 'scheduled', 'published', 'archived');
+
+alter table public.news_articles
+  alter column status type public.news_status_new
+  using status::text::public.news_status_new;
+
+drop type public.news_status;
+alter type public.news_status_new rename to news_status;
+
+alter table public.news_articles alter column status set default 'draft';
+
+-- Recreated verbatim: anonymous readers still only ever see 'published', so
+-- in_review and scheduled articles stay invisible to the public site.
+create policy "published articles are readable by everyone"
+  on public.news_articles
+  for select
+  using (status = 'published');
+
+create policy "article tags are readable by everyone"
+  on public.news_article_tags
+  for select
+  using (
+    exists (
+      select 1
+      from public.news_articles a
+      where a.id = news_article_tags.article_id
+        and a.status = 'published'
+    )
+  );
+
+create policy "published article versions are readable by everyone"
+  on public.article_versions
+  for select
+  using (
+    exists (
+      select 1
+      from public.news_articles a
+      where a.id = article_versions.article_id
+        and a.status = 'published'
+    )
+  );
+
+-- ---------------------------------------------------------------------------
+-- 4. Scheduling column
+-- ---------------------------------------------------------------------------
+alter table public.news_articles
+  add column if not exists scheduled_at timestamptz;
+
+create index if not exists news_articles_scheduled_at_idx
+  on public.news_articles (scheduled_at)
+  where status = 'scheduled';
+
+-- ---------------------------------------------------------------------------
+-- 5. Audit log (append only)
+-- ---------------------------------------------------------------------------
+create table if not exists public.editorial_audit_log (
+  id          uuid primary key default gen_random_uuid(),
+  actor_email text not null,
+  action      text not null,
+  entity      text not null,
+  entity_id   uuid,
+  from_status text,
+  to_status   text,
+  metadata    jsonb not null default '{}'::jsonb,
+  created_at  timestamptz not null default now()
+);
+
+create index if not exists editorial_audit_log_created_at_idx
+  on public.editorial_audit_log (created_at desc);
+
+create index if not exists editorial_audit_log_entity_idx
+  on public.editorial_audit_log (entity, entity_id, created_at desc);
+
+-- ---------------------------------------------------------------------------
+-- 6. Review queue (append only)
+--
+-- Rows are events, not mutable records: requesting a review appends a
+-- 'requested' row, approving appends an 'approved' row, asking for changes
+-- appends a 'changes_requested' row (each carrying its own comment and
+-- resolved_at). A review is *open* when the newest row for an article is
+-- 'requested'. That keeps the whole thread readable and lets the table stay
+-- insert-only for every role, matching editorial_audit_log.
+-- ---------------------------------------------------------------------------
+do $$ begin
+  create type public.review_state as enum ('requested', 'approved', 'changes_requested');
+exception when duplicate_object then null; end $$;
+
+create table if not exists public.article_reviews (
+  id             uuid primary key default gen_random_uuid(),
+  article_id     uuid not null references public.news_articles(id) on delete cascade,
+  version_number integer,
+  state          public.review_state not null default 'requested',
+  requested_by   text not null,
+  reviewer_email text,
+  comment        text,
+  created_at     timestamptz not null default now(),
+  resolved_at    timestamptz
+);
+
+create index if not exists article_reviews_article_id_idx
+  on public.article_reviews (article_id, created_at desc);
+
+create index if not exists article_reviews_open_idx
+  on public.article_reviews (state) where state = 'requested';
+
+-- ---------------------------------------------------------------------------
+-- 7. Status transition guard
+--
+-- Enforced in the database so an invalid change fails even when the REST API
+-- is called directly, bypassing the admin UI and the server actions.
+--
+-- Trigger firing order matters: BEFORE UPDATE triggers run in alphabetical
+-- order, so news_articles_enforce_status runs before
+-- snapshot_article_version_trigger and a rejected transition never leaves a
+-- version snapshot behind.
+-- ---------------------------------------------------------------------------
+create or replace function public.enforce_status_transition()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  allowed text[];
+  v_actor text;
+begin
+  if old.status = new.status then
+    return new;
+  end if;
+
+  allowed := case old.status::text
+    when 'draft'     then array['in_review', 'scheduled', 'published', 'archived']
+    when 'in_review' then array['draft', 'scheduled', 'published']
+    when 'scheduled' then array['draft', 'published', 'archived']
+    when 'published' then array['archived', 'draft']
+    when 'archived'  then array['draft']
+    else array[]::text[]
+  end;
+
+  if not (new.status::text = any(allowed)) then
+    raise exception 'invalid status transition: % -> %', old.status, new.status
+      using errcode = 'check_violation';
+  end if;
+
+  -- Only owners and editors may publish or schedule. The service-role client
+  -- (publishing cron) and direct SQL are exempt from the role check only.
+  if new.status in ('published', 'scheduled')
+     and not public.is_backend_context()
+     and not coalesce(public.can_publish(), false) then
+    raise exception 'insufficient role for status %', new.status
+      using errcode = 'insufficient_privilege';
+  end if;
+
+  if new.status = 'published' and new.published_at is null then
+    new.published_at := now();
+  end if;
+
+  -- Leaving the schedule without publishing clears the pending date so the
+  -- editorial calendar never shows a stale slot.
+  if old.status = 'scheduled' and new.status <> 'published' then
+    new.scheduled_at := null;
+  end if;
+
+  v_actor := coalesce(auth.email(), public.current_jwt_role(), 'system');
+
+  insert into public.editorial_audit_log (
+    actor_email, action, entity, entity_id, from_status, to_status, metadata
+  ) values (
+    v_actor,
+    'status_change',
+    'news_article',
+    new.id,
+    old.status::text,
+    new.status::text,
+    jsonb_build_object('slug', new.slug, 'scheduled_at', new.scheduled_at)
+  );
+
+  return new;
+end;
+$$;
+
+drop trigger if exists news_articles_enforce_status on public.news_articles;
+
+create trigger news_articles_enforce_status
+before update of status on public.news_articles
+for each row execute function public.enforce_status_transition();
+
+-- Role changes are audited by the database too, so the log is complete
+-- regardless of which client performed the update.
+create or replace function public.audit_admin_role_change()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if old.role is distinct from new.role then
+    insert into public.editorial_audit_log (
+      actor_email, action, entity, entity_id, from_status, to_status, metadata
+    ) values (
+      coalesce(auth.email(), public.current_jwt_role(), 'system'),
+      'role_change',
+      'admin_user',
+      null,
+      old.role::text,
+      new.role::text,
+      jsonb_build_object('target_email', new.email)
+    );
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists admin_users_audit_role_change on public.admin_users;
+
+create trigger admin_users_audit_role_change
+after update of role on public.admin_users
+for each row execute function public.audit_admin_role_change();
+
+-- =============================================================================
+-- 8. Row Level Security
+-- =============================================================================
+
+-- ---- news_articles: replace the blanket admin policy from 0002 ----
+drop policy if exists "admins can write articles" on public.news_articles;
+
+-- Contributors only ever see their own articles; everyone else sees the whole
+-- desk. (Published articles remain readable through the public policy above.)
+create policy "editorial read articles"
+  on public.news_articles
+  for select
+  to authenticated
+  using (
+    public.is_admin()
+    and (
+      public.current_editorial_role() <> 'contributor'
+      or public.owns_article(id)
+    )
+  );
+
+-- The one rule for non-publishers: they may never put an article into a *live*
+-- status. Everything else about who may touch which row is decided by the
+-- USING clauses below.
+--
+-- Any admin may create, but only owners and editors may create something that
+-- is already published or scheduled — the transition trigger fires on UPDATE
+-- only, so this check is what closes the insert path.
+create policy "editorial insert articles"
+  on public.news_articles
+  for insert
+  to authenticated
+  with check (
+    public.is_admin()
+    and (
+      coalesce(public.can_publish(), false)
+      or status not in ('published', 'scheduled')
+    )
+  );
+
+-- Owners and editors edit anything. Authors edit their own articles. A
+-- contributor edits their own only while it is still a draft or in review.
+--
+-- The WITH CHECK deliberately allows 'archived' and 'draft' for non-publishers
+-- so it agrees exactly with `allowedTransitionsForRole` in
+-- `src/lib/editorial/transitions.ts` — an author archiving their own piece must
+-- not hit an RLS error for a button the UI offered them.
+create policy "editorial update articles"
+  on public.news_articles
+  for update
+  to authenticated
+  using (
+    public.is_admin()
+    and (
+      coalesce(public.can_publish(), false)
+      or (public.current_editorial_role() = 'author' and public.owns_article(id))
+      or (
+        public.current_editorial_role() = 'contributor'
+        and public.owns_article(id)
+        and status in ('draft', 'in_review')
+      )
+    )
+  )
+  with check (
+    public.is_admin()
+    and (
+      coalesce(public.can_publish(), false)
+      or status not in ('published', 'scheduled')
+    )
+  );
+
+create policy "editorial delete articles"
+  on public.news_articles
+  for delete
+  to authenticated
+  using (public.current_editorial_role() = 'owner');
+
+-- ---- admin_users: only owners manage the team ----
+drop policy if exists "owners manage admin users" on public.admin_users;
+
+create policy "owners manage admin users"
+  on public.admin_users
+  for all
+  to authenticated
+  using (public.current_editorial_role() = 'owner')
+  with check (public.current_editorial_role() = 'owner');
+
+-- ---- article_reviews: admin read, append only, no updates or deletes ----
+alter table public.article_reviews enable row level security;
+
+create policy "admins read article reviews"
+  on public.article_reviews
+  for select
+  to authenticated
+  using (
+    public.is_admin()
+    and (
+      public.current_editorial_role() <> 'contributor'
+      or public.owns_article(article_id)
+    )
+  );
+
+create policy "admins append article reviews"
+  on public.article_reviews
+  for insert
+  to authenticated
+  with check (
+    public.is_admin()
+    and lower(requested_by) = lower(auth.email())
+    and (state = 'requested' or coalesce(public.can_publish(), false))
+  );
+
+-- ---- editorial_audit_log: admin read, append only ----
+alter table public.editorial_audit_log enable row level security;
+
+create policy "admins read editorial audit log"
+  on public.editorial_audit_log
+  for select
+  to authenticated
+  using (public.is_admin());
+
+create policy "admins append editorial audit log"
+  on public.editorial_audit_log
+  for insert
+  to authenticated
+  with check (
+    public.is_admin()
+    and lower(actor_email) = lower(auth.email())
+  );

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "crons": [{ "path": "/api/cron/publish-scheduled", "schedule": "*/10 * * * *" }]
+}


### PR DESCRIPTION
# 🚀 ACTA Pull Request

Mark with an `x` all the checkboxes that apply (like `[x]`)

- [x] Closes #43
- [x] Added tests (if necessary)
- [x] Run tests
- [x] Run formatting
- [ ] Evidence attached
- [x] Commented the code

---

### 📌 Type of Change

- [ ] Documentation (updates to README, docs, or comments)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

---

## 📝 Changes description

Turns the single email allowlist into a real editorial tool: four roles enforced at the database level, a review queue, a publishing calendar, scheduled publishing and an audit log.

**`supabase/migrations/0006_editorial_workflow.sql`** — `editorial_role` enum plus `role` / `author_id` / `display_name` on `admin_users`; the `in_review` and `scheduled` statuses; `scheduled_at` with a partial index; append-only `article_reviews` and `editorial_audit_log`; the `enforce_status_transition` guard; and per-role RLS replacing the blanket `admins can write articles` policy.

**Application layer** — `src/lib/editorial/` holds the transition matrix and role capabilities as pure modules shared by the UI and the tests. New `roles` / `reviews` / `scheduling` / `attestation` services, eleven server actions, the `/api/cron/publish-scheduled` route with `vercel.json`, and the `/admin/team` owner check in `proxy.ts`.

**Admin UI** — `/admin/reviews`, `/admin/calendar` and `/admin/team`, plus `StatusTransitionMenu`, `SchedulePicker`, `ReviewQueue`, `ReviewCommentThread`, `EditorialCalendar` (drag to reschedule) and role-aware navigation.

Nine atomic commits, each one logical change.

### Three deviations from the issue, and why

**1. The migration as specified does not run.** Postgres rejects the enum swap with `cannot alter type of a column used in a policy definition` — three policies depend on `news_articles.status` (on `news_articles`, `news_article_tags` and `article_versions`). The migration now drops and recreates those three verbatim around the swap; the query that finds them is in a comment above the block. Anonymous readers still only ever see `published`.

**2. Closed a hole in the spec.** The transition trigger fires on `UPDATE` only, so a `contributor` could `INSERT` a row with `status='published'` and bypass it. The insert policy now blocks non-publishers from creating anything in a live status.

**3. Reviews are append-only events, and audit rows are written by triggers.** The issue asked for `article_reviews` to be append-only *and* to carry `resolved_at` on the request row — those conflict, so approving appends an `approved` row instead, which also gives the comment thread a real history. Audit rows are written by database triggers rather than by `publishScheduledArticles`, so "every status change and role change writes one row" holds even for direct API calls, with no double-writing.

### Acceptance criteria

| Criterion | How it is verified |
|---|---|
| Migration applies cleanly, rows keep their status | Applied via the Supabase migration runner and against Postgres 15 |
| Four roles stored in `admin_users`, only an owner changes them | RLS integration test |
| Invalid transition fails at the database level | RLS integration test, called straight through PostgREST |
| Contributor cannot publish, schedule, or see others' drafts | Three RLS integration tests |
| Submit for review creates a row tied to the version number | 22 unit tests over the service, plus the append-only RLS tests |
| Scheduling publishes automatically and stamps `published_at` | Unit tests plus the database trigger; see note below |
| Two concurrent cron runs never double-publish | Unit test with a fake modelling Postgres row-lock re-evaluation |
| `/api/cron/publish-scheduled` returns 401 without `CRON_SECRET` | Six route tests |
| Every status and role change writes one audit row | Database tests and RLS integration test |
| `lint`, `test`, `build` pass | `lint` 0 errors, 211 tests pass (222 with the opt-in RLS suite), `build` succeeds |

**222 tests**, including 11 RLS integration tests run against a real local Supabase through PostgREST with real auth users. Those are opt-in so the default suite stays hermetic:

```bash
RUN_RLS_TESTS=1 npm test
```

One criterion remains partially automated, and it is worth calling out: the attestation call is asserted to fire exactly once per published article, but no real Horizon transaction was submitted, since that needs `STELLAR_BLOG_SECRET_KEY` and a deploy. Everything else is covered end to end.

## 📸 Evidence (A Loom/Cap video is required as evidence, we WON'T merge if there's no proof)

https://github.com/user-attachments/assets/a4f0b966-096d-43e2-8776-0f75bfa2fcff




---

## ⏰ Time spent breakdown

_To be filled in._

---

## 🌌 Comments

### Deployment steps

1. Set `CRON_SECRET` (32+ random chars) in the Vercel project env vars. `vercel.json` registers the cron at `*/10 * * * *`.
2. After the migration, every existing admin becomes an `editor` and the oldest row is promoted to `owner` so the team page is reachable.
3. **The `author` and `contributor` roles do nothing until each admin is linked to an `authors` record** — without `author_id`, `owns_article()` returns false. Link them from `/admin/team`.

### Pre-existing issue this PR does not touch

`npm run db:reset` and `db:start` fail on `develop`, unrelated to this work: several committed migrations share a version prefix (`0002` ×2, `0003` ×5) and Supabase keys `schema_migrations` on that number, so it aborts with `duplicate key value violates unique constraint "schema_migrations_pkey" — Key (version)=(0002) already exists` while applying `0002_media_library.sql`. It dates back to #32.

I renumbered locally to run the integration suite and then restored the exact filenames — no tracked migration is modified in this PR. Fixing it means renumbering committed migrations, which would re-apply them on any database that already recorded 0002/0003, so it is a maintainer call rather than something to slip into this branch.

### One judgment call

As written, an `author` can move their own **already published** article back to draft or archive it without an editor — the literal reading of the role table ("edit own articles"). If live content should be editors-only regardless of authorship, it is one line in the `USING` clause of the `editorial update articles` policy. Happy to change it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
