### PR TITLE
Add verifiable author identity with did:stellar and ACTA credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,9 @@ STELLAR_SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
 # Stellar hash anchoring (optional, only needed if using Stellar attestation)
 # STELLAR_SECRET_KEY=<your-stellar-secret-key>
 # STELLAR_NETWORK=testnet   # or "mainnet" / "public"
+
+# ACTA verifiable credentials (author identity)
+# Server-only: NEVER prefix this with NEXT_PUBLIC_.
+ACTA_API_KEY=<64-char hex key created at https://dapp.acta.build>
+ACTA_NETWORK=testnet                 # testnet | mainnet
+NEXT_PUBLIC_ACTA_NETWORK=testnet     # used only for explorer links in the UI

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "products-acta",
       "version": "0.1.0",
       "dependencies": {
+        "@acta-team/credentials": "^1.1.9",
         "@stellar/stellar-sdk": "^15.1.0",
         "@supabase/ssr": "^0.10.2",
         "@supabase/supabase-js": "^2.103.0",
@@ -43,6 +44,44 @@
         "tsx": "^4.19.2",
         "typescript": "^5",
         "vitest": "^4.1.7"
+      }
+    },
+    "node_modules/@acta-team/credentials": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@acta-team/credentials/-/credentials-1.1.9.tgz",
+      "integrity": "sha512-Tn5M21whSft9QEFmQ8HiZCFTOFtHH0k0CmBQjzBmGHaZzpzQC9pG1G5WyF3qQXeHYSM46x3ig7IrN4YyFQeP9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@acta-team/did-stellar": "^0.1.0",
+        "@noble/ed25519": "^2.1.0",
+        "axios": "^1.18.1"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0 <20.0.0",
+        "react-dom": ">=18.0.0 <20.0.0"
+      }
+    },
+    "node_modules/@acta-team/did-stellar": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@acta-team/did-stellar/-/did-stellar-0.1.2.tgz",
+      "integrity": "sha512-RX9aGxaVu1XTA4/oF8ptIR0Cwkgl7T09CXfFs/d6uMoMLmFefZNzL0V0DJ1A5Plf+/nes5EL3dbCikBWHJpczg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/ed25519": "^2.1.0",
+        "@scure/base": "^1.1.9",
+        "@stellar/stellar-sdk": "^15.0.0",
+        "axios": "^1.18.0"
+      },
+      "engines": {
+        "node": ">=22.22.1 <25"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0 <20.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1475,9 +1514,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1493,9 +1529,6 @@
       "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1513,9 +1546,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1531,9 +1561,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1551,9 +1578,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1569,9 +1593,6 @@
       "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1589,9 +1610,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1608,9 +1626,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1626,9 +1641,6 @@
       "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1652,9 +1664,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1676,9 +1685,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1702,9 +1708,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1726,9 +1729,6 @@
       "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1752,9 +1752,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1777,9 +1774,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1801,9 +1795,6 @@
       "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2283,6 +2274,15 @@
       "engines": {
         "node": "^14.21.3 || >=16"
       },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/ed25519": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-2.3.0.tgz",
+      "integrity": "sha512-M7dvXL2B92/M7dw9+gzuydL8qn/jiqNHaoR3Q+cb1q1GHV7uwE17WCyFMG+Y+TZb5izcaXk5TdJRrDUxHXL78A==",
+      "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -4003,9 +4003,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4023,9 +4020,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4043,9 +4037,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4063,9 +4054,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4083,9 +4071,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4103,9 +4088,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4217,6 +4199,15 @@
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
@@ -6154,13 +6145,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
+        "form-data": "^4.0.6",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
@@ -8415,16 +8406,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -8877,9 +8868,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -10698,9 +10689,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -10716,9 +10704,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -10736,9 +10721,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -10754,9 +10736,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -10774,9 +10753,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -10793,9 +10769,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -10811,9 +10784,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -10837,9 +10807,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -10861,9 +10828,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -10887,9 +10851,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -10912,9 +10873,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -10936,9 +10894,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "db:status": "npx supabase status"
   },
   "dependencies": {
+    "@acta-team/credentials": "^1.1.9",
     "@stellar/stellar-sdk": "^15.1.0",
     "@supabase/ssr": "^0.10.2",
     "@supabase/supabase-js": "^2.103.0",

--- a/src/@types/author.ts
+++ b/src/@types/author.ts
@@ -1,4 +1,5 @@
 import type { LocalizedContent } from '@/@types/i18n';
+import type { AuthorCredentialStatus } from '@/@types/credential';
 
 /**
  * An author resolved for one locale. `name` is never translated; `role` and
@@ -15,6 +16,14 @@ export interface Author extends Partial<LocalizedContent> {
     x?: string;
     github?: string;
     linkedin?: string;
+  };
+  /** `did:stellar` identity, when one has been registered for this author. */
+  did?: string;
+  /** The author's ACTA Author credential, when one has been issued. */
+  credential?: {
+    vcId: string;
+    status: AuthorCredentialStatus;
+    revocationReason?: string;
   };
 }
 

--- a/src/@types/credential.ts
+++ b/src/@types/credential.ts
@@ -1,0 +1,45 @@
+/**
+ * Verifiable-credential types for author identity.
+ *
+ * Convention: every type in the `credential` domain lives here.
+ * These mirror `supabase/migrations/0008_author_identities.sql` and the
+ * `@acta-team/credentials` SDK response shapes wrapped by `src/lib/acta/`.
+ */
+
+export type AuthorCredentialStatus = 'pending' | 'active' | 'revoked' | 'failed';
+
+export type ActaNetwork = 'testnet' | 'mainnet';
+
+export interface AuthorIdentity {
+  authorId: string;
+  did: string;
+  stellarAddress: string;
+  vaultContractId?: string;
+  network: ActaNetwork;
+}
+
+export interface AuthorCredential {
+  id: string;
+  authorId: string;
+  vcId: string;
+  role: string;
+  status: AuthorCredentialStatus;
+  issuerDid: string;
+  subjectDid: string;
+  network: ActaNetwork;
+  issueTxId?: string;
+  revokeTxId?: string;
+  issuedAt?: string;
+  revokedAt?: string;
+  revocationReason?: string;
+}
+
+export interface CredentialVerification {
+  status: 'valid' | 'revoked' | 'invalid';
+  since?: string;
+  checkedAt: string;
+  /** True only when `issuerDid` matches the blog's configured issuer DID. */
+  issuedByActaNews: boolean;
+  issuerDid?: string;
+  subjectDid?: string;
+}

--- a/src/@types/news.ts
+++ b/src/@types/news.ts
@@ -8,6 +8,7 @@
 
 import type { LocalizedContent } from '@/@types/i18n';
 import type { Locale } from '@/i18n/config';
+import type { AuthorCredentialStatus } from '@/@types/credential';
 
 export type NewsCategory = 'announcement' | 'product' | 'ecosystem' | 'engineering' | 'community';
 
@@ -20,9 +21,15 @@ export type NewsStatus = 'draft' | 'in_review' | 'scheduled' | 'published' | 'ar
 
 export interface NewsAuthor {
   id: string;
+  slug: string;
   name: string;
   avatarUrl?: string;
   role?: string;
+  did?: string;
+  credential?: {
+    vcId: string;
+    status: AuthorCredentialStatus;
+  };
 }
 
 /**

--- a/src/app/[locale]/(site)/verify/[vcId]/page.tsx
+++ b/src/app/[locale]/(site)/verify/[vcId]/page.tsx
@@ -1,0 +1,12 @@
+import {
+  CredentialVerifyPageContent,
+  credentialVerifyMetadata,
+} from '@/components/modules/credentials';
+
+// Always re-checks status on-chain: a credential can be revoked at any time,
+// and this page's whole purpose is to reflect that immediately.
+export const revalidate = 0;
+
+export const generateMetadata = credentialVerifyMetadata;
+
+export default CredentialVerifyPageContent;

--- a/src/app/admin/(protected)/authors/page.tsx
+++ b/src/app/admin/(protected)/authors/page.tsx
@@ -1,0 +1,5 @@
+import { AdminAuthorsPageContent } from '@/components/modules/admin/pages/AdminAuthorsPage';
+
+export default async function AdminAuthorsPage() {
+  return <AdminAuthorsPageContent />;
+}

--- a/src/components/modules/admin/actions.ts
+++ b/src/components/modules/admin/actions.ts
@@ -851,3 +851,72 @@ export async function restoreArticleVersionAction(formData: FormData): Promise<v
   revalidateArticlePaths(article.slug, await articleSlugs(articleId));
   redirect(`/admin/news/${articleId}/edit`);
 }
+
+// ===========================================================================
+// Author identity & verifiable credentials (issue #42)
+//
+// Every on-chain call is submitted fire-and-forget: the row is claimed
+// `pending` synchronously inside the `src/lib/acta/` functions, the request
+// returns immediately, and the admin sees the final `active` / `failed`
+// state on the next load. A Stellar/ACTA outage must never hang this action.
+// ===========================================================================
+
+function revalidateAuthorPaths(slug: string, vcId?: string | null): void {
+  revalidatePath('/admin/authors');
+
+  for (const locale of LOCALES) {
+    revalidatePath(`/${locale}/authors`);
+    revalidatePath(`/${locale}/authors/${slug}`);
+    if (vcId) revalidatePath(`/${locale}/verify/${vcId}`);
+  }
+}
+
+export async function createAuthorIdentityAction(formData: FormData): Promise<void> {
+  await requireRole('owner', 'editor');
+
+  const authorId = String(formData.get('authorId') ?? '').trim();
+  const authorSlug = String(formData.get('authorSlug') ?? '').trim();
+  if (!authorId || !authorSlug) throw new Error('Missing authorId.');
+
+  const { createAuthorIdentity } = await import('@/lib/acta');
+  await createAuthorIdentity(authorId);
+
+  revalidateAuthorPaths(authorSlug);
+  redirect('/admin/authors');
+}
+
+export async function issueAuthorCredentialAction(formData: FormData): Promise<void> {
+  await requireRole('owner', 'editor');
+
+  const authorId = String(formData.get('authorId') ?? '').trim();
+  const authorSlug = String(formData.get('authorSlug') ?? '').trim();
+  const name = String(formData.get('name') ?? '').trim();
+  const role = String(formData.get('role') ?? '').trim() || 'Author';
+  if (!authorId || !authorSlug || !name) throw new Error('Missing required fields.');
+
+  const { issueAuthorCredential } = await import('@/lib/acta');
+  void issueAuthorCredential({ authorId, authorSlug, name, role }).catch((err) => {
+    console.error('[acta] Failed to issue author credential:', err);
+  });
+
+  revalidateAuthorPaths(authorSlug);
+  redirect('/admin/authors');
+}
+
+export async function revokeAuthorCredentialAction(formData: FormData): Promise<void> {
+  await requireRole('owner', 'editor');
+
+  const authorSlug = String(formData.get('authorSlug') ?? '').trim();
+  const vcId = String(formData.get('vcId') ?? '').trim();
+  const reason = String(formData.get('reason') ?? '').trim();
+  if (!authorSlug || !vcId) throw new Error('Missing vcId.');
+  if (!reason) throw new Error('A revocation reason is required.');
+
+  const { revokeAuthorCredential } = await import('@/lib/acta');
+  void revokeAuthorCredential(vcId, reason).catch((err) => {
+    console.error('[acta] Failed to revoke author credential:', err);
+  });
+
+  revalidateAuthorPaths(authorSlug, vcId);
+  redirect('/admin/authors');
+}

--- a/src/components/modules/admin/index.ts
+++ b/src/components/modules/admin/index.ts
@@ -11,6 +11,7 @@ export { AdminMonthlyReviewEditorPageContent } from './pages/AdminMonthlyReviewE
 export { AdminReviewQueuePageContent } from './pages/AdminReviewQueuePage';
 export { AdminCalendarPageContent } from './pages/AdminCalendarPage';
 export { AdminTeamPageContent } from './pages/AdminTeamPage';
+export { AdminAuthorsPageContent } from './pages/AdminAuthorsPage';
 
 // Editorial UI
 export { RoleBadge } from './ui/RoleBadge';
@@ -22,6 +23,7 @@ export { SchedulePicker } from './ui/SchedulePicker';
 export { ReviewQueue } from './ui/ReviewQueue';
 export { ReviewCommentThread } from './ui/ReviewCommentThread';
 export { EditorialCalendar } from './ui/EditorialCalendar';
+export { AuthorIdentityPanel } from './ui/AuthorIdentityPanel';
 
 // Actions
 export {
@@ -36,6 +38,9 @@ export {
   approveReviewAction,
   requestChangesAction,
   updateTeamMemberRoleAction,
+  createAuthorIdentityAction,
+  issueAuthorCredentialAction,
+  revokeAuthorCredentialAction,
   saveArticleTranslationAction,
   deleteArticleTranslationAction,
   markArticleTranslationCurrentAction,

--- a/src/components/modules/admin/pages/AdminAuthorsPage.tsx
+++ b/src/components/modules/admin/pages/AdminAuthorsPage.tsx
@@ -1,0 +1,74 @@
+import { createClient } from '@/lib/supabase/server';
+import { fetchAuthors } from '@/components/modules/authors/services/authors.service';
+import { requireRole } from '../services/roles.service';
+import { AuthorIdentityPanel } from '../ui/AuthorIdentityPanel';
+
+/** Author identity & credential management for issue #42. Owner/editor only. */
+export async function AdminAuthorsPageContent() {
+  await requireRole('owner', 'editor');
+  const supabase = await createClient();
+  const authors = await fetchAuthors(supabase);
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-2xl border bg-card p-4">
+        <h2 className="text-sm font-semibold">Verifiable author identity</h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Each author gets a real <code>did:stellar</code> identity and an &ldquo;ACTA Author&rdquo;
+          credential issued through the ACTA SDK. Issuance costs an on-chain fee paid by the
+          blog&apos;s issuer account, so it is one credential per author, not per article.
+        </p>
+      </div>
+
+      <div className="overflow-hidden rounded-2xl border bg-card">
+        <table className="w-full text-left text-sm">
+          <thead className="bg-muted/50 text-xs uppercase tracking-[0.14em] text-muted-foreground">
+            <tr>
+              <th className="px-4 py-3">Author</th>
+              <th className="px-4 py-3">DID</th>
+              <th className="px-4 py-3">Credential</th>
+              <th className="px-4 py-3 text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {authors.map((author) => (
+              <tr key={author.id} className="border-t align-top">
+                <td className="px-4 py-3">
+                  <div className="font-medium">{author.name}</div>
+                  <div className="text-xs text-muted-foreground">{author.slug}</div>
+                </td>
+                <td className="px-4 py-3 font-mono text-xs text-muted-foreground">
+                  {author.did ?? '—'}
+                </td>
+                <td className="px-4 py-3 text-xs text-muted-foreground">
+                  {author.credential?.status ?? '—'}
+                </td>
+                <td className="px-4 py-3">
+                  <AuthorIdentityPanel
+                    authorId={author.id}
+                    authorSlug={author.slug}
+                    authorName={author.name}
+                    authorRole={author.role ?? null}
+                    did={author.did}
+                    credential={
+                      author.credential
+                        ? {
+                            vcId: author.credential.vcId,
+                            status: author.credential.status,
+                            revocationReason: author.credential.revocationReason,
+                          }
+                        : undefined
+                    }
+                  />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {authors.length === 0 ? (
+          <p className="px-4 py-8 text-center text-sm text-muted-foreground">No authors yet.</p>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/components/modules/admin/services/attestation.service.ts
+++ b/src/components/modules/admin/services/attestation.service.ts
@@ -27,7 +27,7 @@ export async function attestPublishedArticle(
 ): Promise<void> {
   const { data: row, error } = await supabase
     .from('news_articles')
-    .select('id, slug, title, summary, content, published_at')
+    .select('id, slug, title, summary, content, published_at, author_id')
     .eq('id', article.id)
     .maybeSingle();
 
@@ -51,6 +51,15 @@ export async function attestPublishedArticle(
 
   const version = latestVersion?.version_number ?? 1;
 
+  // The author credential active right now, so the attestation records
+  // which one vouched for the article at publish time.
+  const { data: credential } = await supabase
+    .from('author_credentials')
+    .select('id')
+    .eq('author_id', row.author_id)
+    .eq('status', 'active')
+    .maybeSingle();
+
   // Claim the (article_id, version) slot. An empty result means another run
   // already attested this version: nothing left to do.
   const { data: claimed, error: claimError } = await supabase
@@ -62,6 +71,7 @@ export async function attestPublishedArticle(
         content_hash: contentHash,
         network: getActiveNetwork(),
         status: 'pending',
+        author_credential_id: credential?.id ?? null,
       },
       { onConflict: 'article_id,version', ignoreDuplicates: true }
     )

--- a/src/components/modules/admin/ui/AdminShell.tsx
+++ b/src/components/modules/admin/ui/AdminShell.tsx
@@ -3,7 +3,7 @@ import { adminLogoutAction } from '@/components/modules/admin/actions';
 import { Button } from '@/components/ui/button';
 import { Container } from '@/layouts';
 import type { EditorialRole } from '@/@types/editorial';
-import { canManageTeam } from '@/lib/editorial/permissions';
+import { canManageTeam, canPublish } from '@/lib/editorial/permissions';
 import { RoleBadge } from './RoleBadge';
 
 interface AdminShellProps {
@@ -38,6 +38,12 @@ export function AdminShell({ email, role, title, subtitle, children }: AdminShel
                 <Link href={link.href}>{link.label}</Link>
               </Button>
             ))}
+            {/* Owner/editor-only; the page itself re-checks with requireRole. */}
+            {canPublish(role) ? (
+              <Button asChild variant="ghost" className="w-full justify-start">
+                <Link href="/admin/authors">Authors</Link>
+              </Button>
+            ) : null}
             {/* Owner-only; proxy.ts blocks the route itself for everyone else. */}
             {canManageTeam(role) ? (
               <Button asChild variant="ghost" className="w-full justify-start">

--- a/src/components/modules/admin/ui/AuthorIdentityPanel.tsx
+++ b/src/components/modules/admin/ui/AuthorIdentityPanel.tsx
@@ -1,0 +1,115 @@
+import {
+  createAuthorIdentityAction,
+  issueAuthorCredentialAction,
+  revokeAuthorCredentialAction,
+} from '@/components/modules/admin/actions';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import type { AuthorCredentialStatus } from '@/@types/credential';
+
+interface AuthorIdentityPanelProps {
+  authorId: string;
+  authorSlug: string;
+  authorName: string;
+  authorRole: string | null;
+  did?: string;
+  credential?: {
+    vcId: string;
+    status: AuthorCredentialStatus;
+    revocationReason?: string;
+  };
+}
+
+const STATUS_LABEL: Record<AuthorCredentialStatus, string> = {
+  pending: 'Pending',
+  active: 'Active',
+  revoked: 'Revoked',
+  failed: 'Failed',
+};
+
+const STATUS_CLASS: Record<AuthorCredentialStatus, string> = {
+  pending: 'text-amber-600',
+  active: 'text-emerald-600',
+  revoked: 'text-zinc-500',
+  failed: 'text-red-600',
+};
+
+/**
+ * Per-author actions for issue #42: create identity -> issue credential ->
+ * revoke credential. Every submit is async and never blocks past the claim
+ * step (see `revalidateAuthorPaths` in `actions.ts`); a `failed` credential
+ * is retried with the same "Issue credential" action since
+ * `issueAuthorCredential` is idempotent on `vc_id`.
+ */
+export function AuthorIdentityPanel({
+  authorId,
+  authorSlug,
+  authorName,
+  authorRole,
+  did,
+  credential,
+}: AuthorIdentityPanelProps) {
+  if (!did) {
+    return (
+      <form action={createAuthorIdentityAction} className="flex justify-end">
+        <input type="hidden" name="authorId" value={authorId} />
+        <input type="hidden" name="authorSlug" value={authorSlug} />
+        <Button type="submit" size="sm" variant="outline">
+          Create identity
+        </Button>
+      </form>
+    );
+  }
+
+  if (!credential || credential.status === 'failed') {
+    return (
+      <form action={issueAuthorCredentialAction} className="flex flex-col items-end gap-1">
+        <input type="hidden" name="authorId" value={authorId} />
+        <input type="hidden" name="authorSlug" value={authorSlug} />
+        <input type="hidden" name="name" value={authorName} />
+        <input type="hidden" name="role" value={authorRole ?? 'Author'} />
+        {credential?.status === 'failed' ? (
+          <span className={`text-xs ${STATUS_CLASS.failed}`}>Last attempt failed</span>
+        ) : null}
+        <Button type="submit" size="sm" variant="outline">
+          {credential?.status === 'failed' ? 'Retry issue credential' : 'Issue credential'}
+        </Button>
+      </form>
+    );
+  }
+
+  if (credential.status === 'pending') {
+    return <span className={`text-xs ${STATUS_CLASS.pending}`}>Issuing on-chain…</span>;
+  }
+
+  if (credential.status === 'active') {
+    return (
+      <form
+        action={revokeAuthorCredentialAction}
+        className="flex flex-wrap items-center justify-end gap-2"
+      >
+        <input type="hidden" name="authorSlug" value={authorSlug} />
+        <input type="hidden" name="vcId" value={credential.vcId} />
+        <Input
+          name="reason"
+          placeholder="Revocation reason"
+          required
+          className="h-8 w-40 text-xs"
+        />
+        <Button type="submit" size="sm" variant="destructive">
+          Revoke
+        </Button>
+      </form>
+    );
+  }
+
+  // revoked
+  return (
+    <div className="flex flex-col items-end gap-1 text-xs">
+      <span className={STATUS_CLASS.revoked}>{STATUS_LABEL.revoked}</span>
+      {credential.revocationReason ? (
+        <span className="text-muted-foreground">{credential.revocationReason}</span>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/modules/authors/index.ts
+++ b/src/components/modules/authors/index.ts
@@ -1,5 +1,6 @@
 export { AuthorCard } from './ui/AuthorCard';
 export { AuthorProfile } from './ui/AuthorProfile';
+export { VerifiedAuthorBadge } from './ui/VerifiedAuthorBadge';
 export { fetchAuthors, fetchAuthorBySlug } from './services/authors.service';
 export { AuthorsPageContent, generateAuthorsMetadata } from './pages/AuthorsPage';
 export { AuthorDetailPageContent, generateAuthorDetailMetadata } from './pages/AuthorDetailPage';

--- a/src/components/modules/authors/pages/AuthorDetailPage.tsx
+++ b/src/components/modules/authors/pages/AuthorDetailPage.tsx
@@ -51,7 +51,7 @@ export async function AuthorDetailPageContent({ params }: AuthorDetailPageProps)
 
   return (
     <Container className="py-16">
-      <AuthorProfile author={author} t={t} />
+      <AuthorProfile author={author} t={t} locale={locale} />
     </Container>
   );
 }

--- a/src/components/modules/authors/services/authors.service.ts
+++ b/src/components/modules/authors/services/authors.service.ts
@@ -20,17 +20,35 @@ interface EmbeddedAuthorTranslation {
   bio: string | null;
 }
 
+interface EmbeddedAuthorIdentity {
+  did: string;
+}
+
+interface EmbeddedAuthorCredential {
+  vc_id: string;
+  status: 'pending' | 'active' | 'revoked' | 'failed';
+  revocation_reason: string | null;
+}
+
 type AuthorRowWithTranslations = AuthorRow & {
   translations: EmbeddedAuthorTranslation[] | null;
+  identity: EmbeddedAuthorIdentity | null;
+  credentials: EmbeddedAuthorCredential[] | null;
 };
 
 /**
  * A person's name and avatar are the same in every language; `role` and `bio`
  * are the only prose, so those are what `author_translations` carries.
+ *
+ * `identity`/`credentials` surface the did:stellar identity and the "ACTA
+ * Author" credential (issue #42) so the verified badge never needs a second
+ * round trip.
  */
 const AUTHOR_SELECT = `
   id, slug, name, role, bio, avatar_url, social, created_at, updated_at,
-  translations:author_translations ( locale, role, bio )
+  translations:author_translations ( locale, role, bio ),
+  identity:author_identities ( did ),
+  credentials:author_credentials ( vc_id, status, revocation_reason )
 ` as const;
 
 function mapAuthor(row: AuthorRowWithTranslations, requested: Locale): Author {
@@ -64,6 +82,14 @@ function mapAuthor(row: AuthorRowWithTranslations, requested: Locale): Author {
     sourceLocale: DEFAULT_LOCALE,
     isTranslated: Boolean(match),
     availableLocales: [...new Set(availableLocales)],
+    did: row.identity?.did,
+    credential: row.credentials?.[0]
+      ? {
+          vcId: row.credentials[0].vc_id,
+          status: row.credentials[0].status,
+          revocationReason: row.credentials[0].revocation_reason ?? undefined,
+        }
+      : undefined,
   };
 }
 

--- a/src/components/modules/authors/ui/AuthorCard.tsx
+++ b/src/components/modules/authors/ui/AuthorCard.tsx
@@ -1,22 +1,35 @@
 import Link from 'next/link';
 import type { AuthorCardProps } from '@/@types/author';
 import { withLocale, type Locale } from '@/i18n';
+import { useTranslations } from '@/hooks/useTranslations';
 
 import { AUTHOR_ROUTES } from '../constants';
+import { VerifiedAuthorBadge } from './VerifiedAuthorBadge';
 
 interface Props extends AuthorCardProps {
   locale: Locale;
 }
 
 export function AuthorCard({ author, compact, locale }: Props) {
+  const { t } = useTranslations();
+
   return (
     <Link
       href={withLocale(locale, AUTHOR_ROUTES.detail(author.slug))}
       className="flex items-center gap-3 rounded-2xl border border-zinc-200 p-4 transition-colors hover:border-zinc-300 dark:border-zinc-800 dark:hover:border-zinc-700"
     >
       <div className="h-12 w-12 shrink-0 rounded-full bg-zinc-200 dark:bg-zinc-800" />
-      <div className="flex flex-col">
-        <span className="font-medium text-zinc-900 dark:text-zinc-100">{author.name}</span>
+      <div className="flex flex-col gap-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="font-medium text-zinc-900 dark:text-zinc-100">{author.name}</span>
+          <VerifiedAuthorBadge
+            status={author.credential?.status}
+            vcId={author.credential?.vcId}
+            locale={locale}
+            t={t}
+            asLink={false}
+          />
+        </div>
         {!compact && author.role ? (
           <span className="text-sm text-zinc-500">{author.role}</span>
         ) : null}

--- a/src/components/modules/authors/ui/AuthorProfile.tsx
+++ b/src/components/modules/authors/ui/AuthorProfile.tsx
@@ -1,13 +1,16 @@
 import Image from 'next/image';
 import type { Author } from '@/@types/author';
 import type { Translator } from '@/i18n/translate';
+import type { Locale } from '@/i18n/config';
+import { VerifiedAuthorBadge } from './VerifiedAuthorBadge';
 
 interface AuthorProfileProps {
   author: Author;
   t: Translator;
+  locale: Locale;
 }
 
-export function AuthorProfile({ author, t }: AuthorProfileProps) {
+export function AuthorProfile({ author, t, locale }: AuthorProfileProps) {
   const initials = author.name
     .split(' ')
     .map((n) => n[0])
@@ -31,9 +34,17 @@ export function AuthorProfile({ author, t }: AuthorProfileProps) {
         </div>
       )}
       <div>
-        <h1 className="text-3xl font-semibold tracking-tight text-zinc-950 dark:text-zinc-50">
-          {author.name}
-        </h1>
+        <div className="flex flex-wrap items-center gap-2">
+          <h1 className="text-3xl font-semibold tracking-tight text-zinc-950 dark:text-zinc-50">
+            {author.name}
+          </h1>
+          <VerifiedAuthorBadge
+            status={author.credential?.status}
+            vcId={author.credential?.vcId}
+            locale={locale}
+            t={t}
+          />
+        </div>
         {author.role ? <p className="text-sm text-zinc-500">{author.role}</p> : null}
       </div>
       {author.bio ? (

--- a/src/components/modules/authors/ui/VerifiedAuthorBadge.tsx
+++ b/src/components/modules/authors/ui/VerifiedAuthorBadge.tsx
@@ -1,0 +1,61 @@
+import Link from 'next/link';
+import { BadgeCheck, ShieldOff } from 'lucide-react';
+import type { AuthorCredentialStatus } from '@/@types/credential';
+import type { Translator } from '@/i18n/translate';
+import { withLocale, type Locale } from '@/i18n';
+import { CREDENTIAL_ROUTES } from '@/components/modules/credentials/constants';
+
+interface VerifiedAuthorBadgeProps {
+  status: AuthorCredentialStatus | undefined;
+  vcId: string | undefined;
+  locale: Locale;
+  t: Translator;
+  className?: string;
+  /** Render as a plain `<span>` instead of a `<Link>`, for placements that
+   *  are already nested inside another link (e.g. `AuthorCard`). */
+  asLink?: boolean;
+}
+
+/**
+ * Three states: `active` (green check, links to the public verify page),
+ * `revoked` (muted, still links so the reader can see why), and anything
+ * else (`pending` | `failed` | no credential at all) renders nothing — an
+ * in-progress or failed on-chain issuance must never look like a broken
+ * "verified" claim.
+ */
+export function VerifiedAuthorBadge({
+  status,
+  vcId,
+  locale,
+  t,
+  className,
+  asLink = true,
+}: VerifiedAuthorBadgeProps) {
+  if (!vcId || (status !== 'active' && status !== 'revoked')) return null;
+
+  const verified = status === 'active';
+  const classes = `inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${
+    verified
+      ? 'bg-emerald-50 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-400'
+      : 'bg-zinc-100 text-zinc-500 dark:bg-zinc-900 dark:text-zinc-500'
+  } ${className ?? ''}`;
+
+  const content = (
+    <>
+      {verified ? (
+        <BadgeCheck className="size-3.5" strokeWidth={2} aria-hidden />
+      ) : (
+        <ShieldOff className="size-3.5" strokeWidth={2} aria-hidden />
+      )}
+      {verified ? t('credential.badge.verified') : t('credential.badge.revoked')}
+    </>
+  );
+
+  if (!asLink) return <span className={classes}>{content}</span>;
+
+  return (
+    <Link href={withLocale(locale, CREDENTIAL_ROUTES.verify(vcId))} className={classes}>
+      {content}
+    </Link>
+  );
+}

--- a/src/components/modules/credentials/constants/index.ts
+++ b/src/components/modules/credentials/constants/index.ts
@@ -1,0 +1,4 @@
+/** Unprefixed paths. Wrap with `withLocale(locale, ...)` before rendering. */
+export const CREDENTIAL_ROUTES = {
+  verify: (vcId: string) => `/verify/${vcId}`,
+} as const;

--- a/src/components/modules/credentials/index.ts
+++ b/src/components/modules/credentials/index.ts
@@ -1,0 +1,7 @@
+export { CredentialVerifyCard } from './ui/CredentialVerifyCard';
+export { fetchCredentialVerification } from './services/verify.service';
+export {
+  CredentialVerifyPageContent,
+  credentialVerifyMetadata,
+} from './pages/CredentialVerifyPage';
+export { CREDENTIAL_ROUTES } from './constants';

--- a/src/components/modules/credentials/pages/CredentialVerifyPage.tsx
+++ b/src/components/modules/credentials/pages/CredentialVerifyPage.tsx
@@ -1,0 +1,57 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+
+import { getTranslations } from '@/i18n/dictionaries';
+import { resolveLocaleParams, type LocaleParams } from '@/i18n/params';
+import { buildMetadata } from '@/lib/seo';
+import { Container } from '@/layouts';
+
+import { CREDENTIAL_ROUTES } from '../constants';
+import { fetchCredentialVerification } from '../services/verify.service';
+import { CredentialVerifyCard } from '../ui/CredentialVerifyCard';
+
+interface CredentialVerifyPageProps {
+  params: LocaleParams<{ vcId: string }>;
+}
+
+export async function credentialVerifyMetadata({
+  params,
+}: CredentialVerifyPageProps): Promise<Metadata> {
+  const { locale, vcId } = await resolveLocaleParams(params);
+  const { t } = await getTranslations(locale);
+
+  return buildMetadata({
+    title: t('credential.verify.metaTitle'),
+    description: t('credential.verify.metaDescription'),
+    path: CREDENTIAL_ROUTES.verify(vcId),
+    locale,
+    noIndex: true,
+  });
+}
+
+export async function CredentialVerifyPageContent({ params }: CredentialVerifyPageProps) {
+  const { locale, vcId } = await resolveLocaleParams(params);
+  const { t } = await getTranslations(locale);
+  const verification = await fetchCredentialVerification(vcId);
+
+  // `invalid` covers both "no such vc_id" and "vault says not found": either
+  // way there is nothing to show. A verification service outage (`null`)
+  // also lands here rather than exposing an ambiguous "maybe valid" page.
+  if (!verification || verification.status === 'invalid') notFound();
+
+  return (
+    <Container className="py-16">
+      <div className="mx-auto flex max-w-xl flex-col gap-6">
+        <div>
+          <h1 className="text-3xl font-semibold tracking-tight text-zinc-950 dark:text-zinc-50">
+            {t('credential.verify.title')}
+          </h1>
+          <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
+            {t('credential.verify.description')}
+          </p>
+        </div>
+        <CredentialVerifyCard vcId={vcId} verification={verification} t={t} />
+      </div>
+    </Container>
+  );
+}

--- a/src/components/modules/credentials/services/verify.service.ts
+++ b/src/components/modules/credentials/services/verify.service.ts
@@ -1,0 +1,18 @@
+import type { CredentialVerification } from '@/@types/credential';
+
+/**
+ * Re-checks a credential's status on-chain. Never throws: the `/verify`
+ * page must render either way, so an ACTA outage or misconfiguration
+ * degrades to "unable to verify right now" instead of a 500.
+ */
+export async function fetchCredentialVerification(
+  vcId: string
+): Promise<CredentialVerification | null> {
+  try {
+    const { verifyAuthorCredential } = await import('@/lib/acta');
+    return await verifyAuthorCredential(vcId);
+  } catch (err) {
+    console.error(`[acta] Failed to verify credential "${vcId}":`, err);
+    return null;
+  }
+}

--- a/src/components/modules/credentials/ui/CredentialVerifyCard.tsx
+++ b/src/components/modules/credentials/ui/CredentialVerifyCard.tsx
@@ -1,0 +1,93 @@
+import { BadgeCheck, ShieldOff, ShieldQuestion } from 'lucide-react';
+import type { CredentialVerification } from '@/@types/credential';
+import type { Translator } from '@/i18n/translate';
+import { CopyChip } from '@/components/modules/news/ui/embeds/CopyChip';
+import { formatTimestamp } from '@/lib/stellar/format';
+
+interface CredentialVerifyCardProps {
+  vcId: string;
+  verification: CredentialVerification;
+  t: Translator;
+}
+
+const STATUS_STYLES: Record<CredentialVerification['status'], string> = {
+  valid: 'text-emerald-700 dark:text-emerald-400',
+  revoked: 'text-amber-700 dark:text-amber-400',
+  invalid: 'text-zinc-500',
+};
+
+const STATUS_ICONS: Record<CredentialVerification['status'], typeof BadgeCheck> = {
+  valid: BadgeCheck,
+  revoked: ShieldOff,
+  invalid: ShieldQuestion,
+};
+
+export function CredentialVerifyCard({ vcId, verification, t }: CredentialVerifyCardProps) {
+  const StatusIcon = STATUS_ICONS[verification.status];
+  const statusLabel = {
+    valid: t('credential.verify.statusValid'),
+    revoked: t('credential.verify.statusRevoked'),
+    invalid: t('credential.verify.statusInvalid'),
+  }[verification.status];
+
+  return (
+    <div className="flex flex-col gap-4 rounded-2xl border border-zinc-200 p-6 dark:border-zinc-800">
+      <div
+        className={`flex items-center gap-2 text-lg font-semibold ${STATUS_STYLES[verification.status]}`}
+      >
+        <StatusIcon className="size-5" strokeWidth={2} aria-hidden />
+        {statusLabel}
+      </div>
+
+      <dl className="grid gap-3 text-sm">
+        <div className="flex flex-col gap-1">
+          <dt className="text-zinc-500">{t('credential.verify.credentialIdLabel')}</dt>
+          <dd>
+            <CopyChip value={vcId} display={vcId} />
+          </dd>
+        </div>
+
+        {verification.subjectDid ? (
+          <div className="flex flex-col gap-1">
+            <dt className="text-zinc-500">{t('credential.verify.subjectLabel')}</dt>
+            <dd>
+              <CopyChip value={verification.subjectDid} />
+            </dd>
+          </div>
+        ) : null}
+
+        {verification.issuerDid ? (
+          <div className="flex flex-col gap-1">
+            <dt className="text-zinc-500">{t('credential.verify.issuerLabel')}</dt>
+            <dd className="flex flex-wrap items-center gap-2">
+              <CopyChip value={verification.issuerDid} />
+              <span
+                className={
+                  verification.issuedByActaNews
+                    ? 'text-xs text-emerald-700 dark:text-emerald-400'
+                    : 'text-xs text-amber-700 dark:text-amber-400'
+                }
+              >
+                {verification.issuedByActaNews
+                  ? t('credential.verify.issuedByActaNews')
+                  : t('credential.verify.issuedByOther')}
+              </span>
+            </dd>
+          </div>
+        ) : null}
+
+        {verification.since ? (
+          <div className="flex flex-col gap-1">
+            <dt className="text-zinc-500">{t('credential.verify.sinceLabel')}</dt>
+            <dd>{formatTimestamp(verification.since)}</dd>
+          </div>
+        ) : null}
+
+        <div className="flex flex-col gap-1">
+          <dt className="text-zinc-500">{t('credential.verify.checkedAtLabel')}</dt>
+          <dd>{formatTimestamp(verification.checkedAt)}</dd>
+        </div>
+      </dl>
+    </div>
+  );
+}

--- a/src/components/modules/news/pages/NewsDetailPage.tsx
+++ b/src/components/modules/news/pages/NewsDetailPage.tsx
@@ -106,7 +106,13 @@ export async function NewsDetailPageContent({ params }: NewsDetailPageProps) {
         />
         <TagCloud tags={article.tags.map((tag) => ({ slug: tag, label: tag }))} />
         <AttestationBadge attestation={attestation} />
-        <AttestationPanel attestation={attestation} articleHash={articleHash} />
+        <AttestationPanel
+          attestation={attestation}
+          articleHash={articleHash}
+          authorDid={article.author.did}
+          authorCredentialVcId={article.author.credential?.vcId}
+          locale={locale}
+        />
 
         {/* Version history / audit trail link */}
         <div className="flex items-center gap-2 border-t border-zinc-100 pt-4 dark:border-zinc-800">

--- a/src/components/modules/news/services/news.service.ts
+++ b/src/components/modules/news/services/news.service.ts
@@ -39,8 +39,18 @@ interface EmbeddedTranslation {
  * Row shape returned by the Supabase query below, with the author, article tags
  * and translations joined in.
  */
+type EmbeddedAuthorCredential = {
+  vc_id: string;
+  status: 'pending' | 'active' | 'revoked' | 'failed';
+};
+
 type ArticleRowWithRelations = ArticleRow & {
-  author: AuthorRow | null;
+  author:
+    | (AuthorRow & {
+        identity: { did: string } | null;
+        credentials: EmbeddedAuthorCredential[] | null;
+      })
+    | null;
   tags: ArticleTagRow[];
   translations: EmbeddedTranslation[] | null;
 };
@@ -61,7 +71,11 @@ const ARTICLE_SELECT = `
   created_at,
   updated_at,
   author_id,
-  author:authors ( id, slug, name, role, bio, avatar_url, social, created_at, updated_at ),
+  author:authors (
+    id, slug, name, role, bio, avatar_url, social, created_at, updated_at,
+    identity:author_identities ( did ),
+    credentials:author_credentials ( vc_id, status )
+  ),
   tags:news_article_tags ( tag_slug ),
   translations:article_translations ( locale, slug, title, summary, content, source_content_hash )
 ` as const;
@@ -123,9 +137,14 @@ function resolveArticle(row: ArticleRowWithRelations, requested: Locale): NewsAr
     tags: row.tags?.map((tag: ArticleTagRow) => tag.tag_slug) ?? [],
     author: {
       id: row.author?.id ?? row.author_id,
+      slug: row.author?.slug ?? row.author_id,
       name: row.author?.name ?? 'Unknown',
       avatarUrl: row.author?.avatar_url ?? undefined,
       role: row.author?.role ?? undefined,
+      did: row.author?.identity?.did,
+      credential: row.author?.credentials?.[0]
+        ? { vcId: row.author.credentials[0].vc_id, status: row.author.credentials[0].status }
+        : undefined,
     },
     publishedAt: row.published_at ?? row.created_at,
     updatedAt: row.updated_at,

--- a/src/components/modules/news/ui/AttestationPanel.tsx
+++ b/src/components/modules/news/ui/AttestationPanel.tsx
@@ -1,11 +1,24 @@
+import Link from 'next/link';
 import type { ArticleAttestation } from '@/@types/attestation';
+import { withLocale, type Locale } from '@/i18n';
+import { CREDENTIAL_ROUTES } from '@/components/modules/credentials/constants';
 
 interface AttestationPanelProps {
   attestation: ArticleAttestation | null;
   articleHash: string;
+  /** The author credential active when this article was attested, if any. */
+  authorDid?: string;
+  authorCredentialVcId?: string;
+  locale: Locale;
 }
 
-export function AttestationPanel({ attestation, articleHash }: AttestationPanelProps) {
+export function AttestationPanel({
+  attestation,
+  articleHash,
+  authorDid,
+  authorCredentialVcId,
+  locale,
+}: AttestationPanelProps) {
   if (!attestation) return null;
   const verified = attestation.content_hash === articleHash;
   return (
@@ -36,6 +49,24 @@ export function AttestationPanel({ attestation, articleHash }: AttestationPanelP
           {verified ? 'Verified' : 'Hash mismatch'}
         </span>
       </div>
+      {authorDid ? (
+        <div className="mb-1">
+          Author: <span className="font-mono break-all">{authorDid}</span>
+          {authorCredentialVcId ? (
+            <>
+              {' '}
+              (
+              <Link
+                href={withLocale(locale, CREDENTIAL_ROUTES.verify(authorCredentialVcId))}
+                className="text-blue-600 underline"
+              >
+                verify
+              </Link>
+              )
+            </>
+          ) : null}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/components/modules/news/ui/NewsCard.tsx
+++ b/src/components/modules/news/ui/NewsCard.tsx
@@ -7,6 +7,7 @@ import { NEWS_ROUTES } from '@/components/modules/news/constants';
 import { formatPublishedDate, getCategoryLabel } from '@/components/modules/news/utils';
 import { useTranslations } from '@/hooks/useTranslations';
 import { LOCALE_NAMES, withLocale } from '@/i18n';
+import { VerifiedAuthorBadge } from '@/components/modules/authors/ui/VerifiedAuthorBadge';
 
 /**
  * Presentational card for a news article.
@@ -71,11 +72,17 @@ export function NewsCard({ article }: NewsCardProps) {
           {article.summary}
         </p>
 
-        <footer className="mt-auto flex items-center gap-2 pt-3 text-xs text-zinc-500">
+        <footer className="mt-auto flex flex-wrap items-center gap-2 pt-3 text-xs text-zinc-500">
           <span className="font-medium text-zinc-700 dark:text-zinc-300">
             {article.author.name}
           </span>
           {article.author.role ? <span>· {article.author.role}</span> : null}
+          <VerifiedAuthorBadge
+            status={article.author.credential?.status}
+            vcId={article.author.credential?.vcId}
+            locale={locale}
+            t={t}
+          />
         </footer>
       </div>
     </article>

--- a/src/components/modules/news/ui/NewsDetail.tsx
+++ b/src/components/modules/news/ui/NewsDetail.tsx
@@ -4,6 +4,7 @@ import { Languages } from 'lucide-react';
 import type { NewsDetailProps } from '@/@types/news';
 import { formatPublishedDate, getCategoryLabel } from '@/components/modules/news/utils';
 import { ArticleContent } from '@/components/modules/news/ui/embeds/ArticleContent';
+import { VerifiedAuthorBadge } from '@/components/modules/authors/ui/VerifiedAuthorBadge';
 import { LOCALE_NAMES, type Locale } from '@/i18n/config';
 import type { Translator } from '@/i18n/translate';
 
@@ -56,10 +57,18 @@ export function NewsDetail({ article, locale, t }: Props) {
       </p>
 
       <div className="flex items-center gap-3 border-y border-zinc-200 py-4 text-sm dark:border-zinc-800">
-        <div className="flex flex-col">
-          <span className="font-medium text-zinc-900 dark:text-zinc-100">
-            {article.author.name}
-          </span>
+        <div className="flex flex-col gap-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="font-medium text-zinc-900 dark:text-zinc-100">
+              {article.author.name}
+            </span>
+            <VerifiedAuthorBadge
+              status={article.author.credential?.status}
+              vcId={article.author.credential?.vcId}
+              locale={locale}
+              t={t}
+            />
+          </div>
           {article.author.role ? (
             <span className="text-zinc-500">{article.author.role}</span>
           ) : null}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -200,6 +200,29 @@
     "eyebrow": "Tag",
     "fallbackTitle": "Tag"
   },
+  "credential": {
+    "badge": {
+      "verified": "Verified ACTA author",
+      "revoked": "Credential revoked"
+    },
+    "verify": {
+      "metaTitle": "Verify credential",
+      "metaDescription": "Check the status of an ACTA Author verifiable credential.",
+      "title": "Credential verification",
+      "description": "This confirms the credential exists in its owner's vault and its current on-chain status. It is re-checked on every visit.",
+      "statusLabel": "Status",
+      "statusValid": "Valid",
+      "statusRevoked": "Revoked",
+      "statusInvalid": "Not found",
+      "credentialIdLabel": "Credential ID",
+      "issuerLabel": "Issuer DID",
+      "subjectLabel": "Subject DID",
+      "issuedByActaNews": "Issued by ACTA News",
+      "issuedByOther": "Issuer does not match ACTA News",
+      "sinceLabel": "Since",
+      "checkedAtLabel": "Checked at"
+    }
+  },
   "login": {
     "metaTitle": "Sign in",
     "metaDescription": "Sign in to {siteName} (preview UI).",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -200,6 +200,29 @@
     "eyebrow": "Etiqueta",
     "fallbackTitle": "Etiqueta"
   },
+  "credential": {
+    "badge": {
+      "verified": "Autor verificado por ACTA",
+      "revoked": "Credencial revocada"
+    },
+    "verify": {
+      "metaTitle": "Verificar credencial",
+      "metaDescription": "Consulta el estado de una credencial verificable de ACTA Author.",
+      "title": "Verificación de credencial",
+      "description": "Esto confirma que la credencial existe en la bóveda de su titular y su estado actual en la cadena. Se vuelve a comprobar en cada visita.",
+      "statusLabel": "Estado",
+      "statusValid": "Válida",
+      "statusRevoked": "Revocada",
+      "statusInvalid": "No encontrada",
+      "credentialIdLabel": "ID de credencial",
+      "issuerLabel": "DID del emisor",
+      "subjectLabel": "DID del titular",
+      "issuedByActaNews": "Emitida por ACTA News",
+      "issuedByOther": "El emisor no coincide con ACTA News",
+      "sinceLabel": "Desde",
+      "checkedAtLabel": "Verificado el"
+    }
+  },
   "login": {
     "metaTitle": "Iniciar sesión",
     "metaDescription": "Inicia sesión en {siteName} (interfaz de vista previa).",

--- a/src/lib/acta/__tests__/credentials.test.ts
+++ b/src/lib/acta/__tests__/credentials.test.ts
@@ -1,0 +1,330 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ActaApiError } from '@acta-team/credentials';
+
+/**
+ * Fake author_credentials table + a minimal Supabase-shaped query builder.
+ * Supports exactly the chains `src/lib/acta/credentials.ts` uses:
+ *   .upsert(payload, opts)
+ *   .select(cols).eq(col, val).single() / .maybeSingle()
+ *   .update(payload).eq(col, val)                       (awaited directly)
+ *   .update(payload).eq(col, val).select(cols).single()
+ */
+interface FakeRow {
+  id: string;
+  author_id: string;
+  vc_id: string;
+  role: string;
+  status: 'pending' | 'active' | 'revoked' | 'failed';
+  issuer_did: string;
+  subject_did: string;
+  network: 'testnet' | 'mainnet';
+  issue_tx_id: string | null;
+  revoke_tx_id: string | null;
+  issued_at: string | null;
+  revoked_at: string | null;
+  revocation_reason: string | null;
+}
+
+function createFakeSupabase(rows: FakeRow[]) {
+  let nextId = 1;
+
+  function from() {
+    let op: 'select' | 'update' | 'upsert' = 'select';
+    let payload: Partial<FakeRow> | undefined;
+    let upsertOpts: { onConflict?: string; ignoreDuplicates?: boolean } | undefined;
+    const filters: Array<[keyof FakeRow, unknown]> = [];
+    let mode: 'single' | 'maybeSingle' | 'many' = 'many';
+
+    function matches(row: FakeRow) {
+      return filters.every(([col, val]) => row[col] === val);
+    }
+
+    async function execute() {
+      if (op === 'upsert' && payload) {
+        const existing = rows.find((r) => r.vc_id === payload!.vc_id);
+        if (existing) {
+          if (!upsertOpts?.ignoreDuplicates) Object.assign(existing, payload);
+          return { data: null, error: null };
+        }
+        const base = payload as FakeRow;
+        const row: FakeRow = {
+          ...base,
+          id: `row-${nextId++}`,
+          issue_tx_id: base.issue_tx_id ?? null,
+          revoke_tx_id: base.revoke_tx_id ?? null,
+          issued_at: base.issued_at ?? null,
+          revoked_at: base.revoked_at ?? null,
+          revocation_reason: base.revocation_reason ?? null,
+        };
+        rows.push(row);
+        return { data: null, error: null };
+      }
+
+      if (op === 'update') {
+        const matched = rows.filter(matches);
+        matched.forEach((r) => Object.assign(r, payload));
+        if (mode === 'single') {
+          return matched[0]
+            ? { data: matched[0], error: null }
+            : { data: null, error: new Error('not found') };
+        }
+        if (mode === 'maybeSingle') return { data: matched[0] ?? null, error: null };
+        return { data: matched, error: null };
+      }
+
+      const matched = rows.filter(matches);
+      if (mode === 'single') {
+        return matched[0]
+          ? { data: matched[0], error: null }
+          : { data: null, error: new Error('not found') };
+      }
+      if (mode === 'maybeSingle') return { data: matched[0] ?? null, error: null };
+      return { data: matched, error: null };
+    }
+
+    const builder = {
+      upsert(value: Partial<FakeRow>, opts?: { onConflict?: string; ignoreDuplicates?: boolean }) {
+        op = 'upsert';
+        payload = value;
+        upsertOpts = opts;
+        return builder;
+      },
+      update(value: Partial<FakeRow>) {
+        op = 'update';
+        payload = value;
+        return builder;
+      },
+      select() {
+        return builder;
+      },
+      eq(col: keyof FakeRow, val: unknown) {
+        filters.push([col, val]);
+        return builder;
+      },
+      single() {
+        mode = 'single';
+        return execute();
+      },
+      maybeSingle() {
+        mode = 'maybeSingle';
+        return execute();
+      },
+      then(onFulfilled: (value: unknown) => unknown, onRejected?: (reason: unknown) => unknown) {
+        return execute().then(onFulfilled, onRejected);
+      },
+    };
+
+    return builder;
+  }
+
+  return { from };
+}
+
+const AUTHOR_IDENTITY = {
+  authorId: 'author-1',
+  did: 'did:stellar:testnet:author1',
+  stellarAddress: 'GAUTHOR1111111111111111111111111111111111111111111',
+  network: 'testnet' as const,
+};
+
+const ISSUER_IDENTITY = {
+  did: 'did:stellar:testnet:issuer1',
+  controller: 'GAUTHOR1111111111111111111111111111111111111111111',
+  assertionPublicKeyMultibase: 'z-assertion',
+  assertionPrivateKeyHex: 'aa',
+  assertionPublicKeyHex: 'bb',
+};
+
+let rows: FakeRow[];
+
+const createAdminClient = vi.fn();
+const createAuthorIdentity = vi.fn();
+const getAuthorIdentity = vi.fn();
+const createServerSigner = vi.fn();
+const getActaClient = vi.fn();
+const getActaNetwork = vi.fn();
+
+const vaultCreate = vi.fn();
+const vcIssue = vi.fn();
+const revokeCredentialViaApi = vi.fn();
+const vaultVerify = vi.fn();
+const getOrCreateIssuerIdentity = vi.fn();
+const getIssuerIdentity = vi.fn();
+
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminClient: () => createAdminClient(),
+}));
+
+vi.mock('@/config/site', () => ({
+  siteConfig: { url: 'https://news.acta.build' },
+}));
+
+vi.mock('@/lib/stellar/config', () => ({
+  STELLAR_BLOG_SECRET_KEY: 'SFAKESECRETSFAKESECRETSFAKESECRETSFAKESECRETSFAKESECRET',
+}));
+
+vi.mock('../identity', () => ({
+  createAuthorIdentity: (...args: unknown[]) => createAuthorIdentity(...args),
+  getAuthorIdentity: (...args: unknown[]) => getAuthorIdentity(...args),
+}));
+
+vi.mock('../signer', () => ({
+  createServerSigner: (...args: unknown[]) => createServerSigner(...args),
+}));
+
+vi.mock('../client', () => ({
+  getActaClient: () => getActaClient(),
+  getActaNetwork: () => getActaNetwork(),
+}));
+
+const { issueAuthorCredential, revokeAuthorCredential, verifyAuthorCredential } =
+  await import('../credentials');
+
+const PREPARE = { xdr: 'unsigned-xdr', network: 'Test SDF Network ; September 2015' };
+
+beforeEach(() => {
+  rows = [];
+  createAdminClient.mockReset().mockImplementation(() => createFakeSupabase(rows));
+  createAuthorIdentity.mockReset().mockResolvedValue(AUTHOR_IDENTITY);
+  getAuthorIdentity.mockReset().mockResolvedValue(AUTHOR_IDENTITY);
+  createServerSigner.mockReset().mockReturnValue(async (xdr: string) => `signed:${xdr}`);
+  getActaNetwork.mockReset().mockReturnValue('testnet');
+
+  vaultCreate
+    .mockReset()
+    .mockImplementation(async (payload: { signedXdr?: string }) =>
+      payload.signedXdr ? { tx_id: 'vault-tx' } : PREPARE
+    );
+  vcIssue
+    .mockReset()
+    .mockImplementation(async (payload: { signedXdr?: string }) =>
+      payload.signedXdr ? { tx_id: 'vc-tx' } : PREPARE
+    );
+  revokeCredentialViaApi
+    .mockReset()
+    .mockImplementation(async (payload: { signedXdr?: string }) =>
+      payload.signedXdr ? { tx_id: 'revoke-tx' } : PREPARE
+    );
+  vaultVerify.mockReset();
+  getOrCreateIssuerIdentity.mockReset().mockResolvedValue(ISSUER_IDENTITY);
+  getIssuerIdentity.mockReset().mockResolvedValue(ISSUER_IDENTITY);
+
+  getActaClient.mockReset().mockReturnValue({
+    vaultCreate,
+    vcIssue,
+    revokeCredentialViaApi,
+    vaultVerify,
+    getOrCreateIssuerIdentity,
+    getIssuerIdentity,
+  });
+});
+
+const INPUT = { authorId: 'author-1', authorSlug: 'jane-doe', name: 'Jane Doe', role: 'Editor' };
+
+describe('issueAuthorCredential', () => {
+  it('does not create a duplicate row when called twice for the same author', async () => {
+    const first = await issueAuthorCredential(INPUT);
+    const second = await issueAuthorCredential(INPUT);
+
+    expect(rows).toHaveLength(1);
+    expect(first.status).toBe('active');
+    expect(second.id).toBe(first.id);
+    // The second call short-circuits on the already-`active` row: no repeat chain calls.
+    expect(vcIssue).toHaveBeenCalledTimes(2); // prepare + submit, once total
+  });
+
+  it('treats vault_already_exists as success and still issues the credential', async () => {
+    vaultCreate.mockRejectedValueOnce(
+      new ActaApiError({ status: 409, code: 'vault_already_exists', message: 'already exists' })
+    );
+
+    const result = await issueAuthorCredential(INPUT);
+
+    expect(result.status).toBe('active');
+    expect(result.issueTxId).toBe('vc-tx');
+  });
+
+  it('leaves the row failed without issued_at when the submit step fails', async () => {
+    vcIssue.mockImplementationOnce(async () => PREPARE);
+    vcIssue.mockImplementationOnce(async () => {
+      throw new ActaApiError({ status: 500, code: 'internal', message: 'boom' });
+    });
+
+    await expect(issueAuthorCredential(INPUT)).rejects.toThrow();
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe('failed');
+    expect(rows[0].issued_at).toBeNull();
+    expect(rows[0].issue_tx_id).toBeNull();
+  });
+});
+
+describe('verifyAuthorCredential', () => {
+  async function seedIssuedCredential() {
+    await issueAuthorCredential(INPUT);
+  }
+
+  it('maps a valid credential', async () => {
+    await seedIssuedCredential();
+    vaultVerify.mockResolvedValueOnce({ status: 'valid' });
+
+    const result = await verifyAuthorCredential('acta-author-jane-doe');
+
+    expect(result.status).toBe('valid');
+    expect(result.issuedByActaNews).toBe(true);
+  });
+
+  it('maps a revoked credential', async () => {
+    await seedIssuedCredential();
+    vaultVerify.mockResolvedValueOnce({ status: 'revoked', since: '2026-01-01T00:00:00Z' });
+
+    const result = await verifyAuthorCredential('acta-author-jane-doe');
+
+    expect(result.status).toBe('revoked');
+    expect(result.since).toBe('2026-01-01T00:00:00Z');
+  });
+
+  it('maps an unknown vc_id to invalid', async () => {
+    const result = await verifyAuthorCredential('acta-author-does-not-exist');
+
+    expect(result.status).toBe('invalid');
+    expect(result.issuedByActaNews).toBe(false);
+  });
+
+  it('maps a 404 from the vault to invalid', async () => {
+    await seedIssuedCredential();
+    vaultVerify.mockRejectedValueOnce(
+      new ActaApiError({ status: 404, code: 'not_found', message: 'no such vc' })
+    );
+
+    const result = await verifyAuthorCredential('acta-author-jane-doe');
+
+    expect(result.status).toBe('invalid');
+  });
+
+  it('reports issuer DID mismatch as not issued by ACTA News', async () => {
+    await seedIssuedCredential();
+    vaultVerify.mockResolvedValueOnce({ status: 'valid' });
+    getIssuerIdentity.mockResolvedValueOnce({
+      ...ISSUER_IDENTITY,
+      did: 'did:stellar:testnet:someone-else',
+    });
+
+    const result = await verifyAuthorCredential('acta-author-jane-doe');
+
+    expect(result.status).toBe('valid');
+    expect(result.issuedByActaNews).toBe(false);
+  });
+});
+
+describe('revokeAuthorCredential', () => {
+  it('marks the credential revoked with a reason', async () => {
+    await issueAuthorCredential(INPUT);
+
+    const result = await revokeAuthorCredential('acta-author-jane-doe', 'left the team');
+
+    expect(result.status).toBe('revoked');
+    expect(result.revocationReason).toBe('left the team');
+    expect(result.revokeTxId).toBe('revoke-tx');
+  });
+});

--- a/src/lib/acta/client.ts
+++ b/src/lib/acta/client.ts
@@ -1,0 +1,28 @@
+import 'server-only';
+
+import { ActaClient, mainNet, testNet } from '@acta-team/credentials';
+import type { ActaNetwork } from '@/@types/credential';
+import { SupabaseIssuerIdentityStorage } from './identity-storage';
+
+/** `ACTA_NETWORK` (server) selects which ACTA API the blog issues against. */
+export function getActaNetwork(): ActaNetwork {
+  return process.env.ACTA_NETWORK === 'mainnet' ? 'mainnet' : 'testnet';
+}
+
+const BASE_URL = getActaNetwork() === 'mainnet' ? mainNet : testNet;
+
+let client: ActaClient | null = null;
+
+/** Singleton ACTA SDK client, configured with the durable Supabase-backed
+ * issuer identity storage so the issuer DID survives server restarts. */
+export function getActaClient(): ActaClient {
+  if (client) return client;
+
+  const apiKey = process.env.ACTA_API_KEY;
+  if (!apiKey) throw new Error('ACTA_API_KEY is not set');
+
+  client = new ActaClient(BASE_URL, apiKey, {
+    storage: new SupabaseIssuerIdentityStorage(),
+  });
+  return client;
+}

--- a/src/lib/acta/credentials.ts
+++ b/src/lib/acta/credentials.ts
@@ -1,0 +1,314 @@
+import 'server-only';
+
+import { isTxPrepareResponse, isTxSubmitResponse, type Signer } from '@acta-team/credentials';
+import { createAdminClient } from '@/lib/supabase/admin';
+import { STELLAR_BLOG_SECRET_KEY } from '@/lib/stellar/config';
+import { siteConfig } from '@/config/site';
+import type { AuthorCredential, CredentialVerification } from '@/@types/credential';
+import { getActaClient, getActaNetwork } from './client';
+import { createServerSigner } from './signer';
+import { createAuthorIdentity, getAuthorIdentity } from './identity';
+import { isVaultAlreadyExistsError, toActaApiError } from './errors';
+
+export interface IssueAuthorCredentialInput {
+  authorId: string;
+  authorSlug: string;
+  name: string;
+  role: string;
+}
+
+type CredentialRow = {
+  id: string;
+  author_id: string;
+  vc_id: string;
+  role: string;
+  status: 'pending' | 'active' | 'revoked' | 'failed';
+  issuer_did: string;
+  subject_did: string;
+  network: 'testnet' | 'mainnet';
+  issue_tx_id: string | null;
+  revoke_tx_id: string | null;
+  issued_at: string | null;
+  revoked_at: string | null;
+  revocation_reason: string | null;
+};
+
+function mapRow(row: CredentialRow): AuthorCredential {
+  return {
+    id: row.id,
+    authorId: row.author_id,
+    vcId: row.vc_id,
+    role: row.role,
+    status: row.status,
+    issuerDid: row.issuer_did,
+    subjectDid: row.subject_did,
+    network: row.network,
+    issueTxId: row.issue_tx_id ?? undefined,
+    revokeTxId: row.revoke_tx_id ?? undefined,
+    issuedAt: row.issued_at ?? undefined,
+    revokedAt: row.revoked_at ?? undefined,
+    revocationReason: row.revocation_reason ?? undefined,
+  };
+}
+
+function blogSigner(): Signer {
+  if (!STELLAR_BLOG_SECRET_KEY) throw new Error('Missing STELLAR_BLOG_SECRET_KEY');
+  return createServerSigner(STELLAR_BLOG_SECRET_KEY);
+}
+
+/** Get or create (and persist) the ACTA issuer identity for this blog. */
+async function ensureIssuerIdentity(controller: string) {
+  const client = getActaClient();
+  return client.getOrCreateIssuerIdentity({
+    controller,
+    signTransaction: blogSigner(),
+  });
+}
+
+/**
+ * Ensure the shared credential vault owned by the blog account exists.
+ * Authors have no wallet of their own, so every author credential lives in
+ * this one vault, disambiguated by `vcId` — see `src/lib/acta/identity.ts`
+ * for the same reasoning applied to author DIDs. `vault_already_exists` is
+ * expected from the second author onward and is treated as success.
+ */
+async function ensureVault(owner: string, didUri: string): Promise<void> {
+  const client = getActaClient();
+  const signer = blogSigner();
+
+  let prepared;
+  try {
+    prepared = await client.vaultCreate({ owner, didUri, sourcePublicKey: owner });
+  } catch (err) {
+    if (isVaultAlreadyExistsError(err)) return;
+    throw toActaApiError(err);
+  }
+
+  if (!isTxPrepareResponse(prepared)) return;
+
+  const signedXdr = await signer(prepared.xdr, { networkPassphrase: prepared.network });
+
+  try {
+    await client.vaultCreate({ signedXdr });
+  } catch (err) {
+    if (isVaultAlreadyExistsError(err)) return;
+    throw toActaApiError(err);
+  }
+}
+
+/**
+ * Issues an "ACTA Author" credential into the shared author vault.
+ *
+ * Flow: resolve issuer identity -> resolve author identity -> ensure the
+ * vault exists -> issue the VC -> persist the result. Every step is
+ * idempotent so a partial failure can be retried without creating
+ * duplicates: the row is claimed by `vc_id` (unique) before anything is
+ * submitted on-chain, and re-running for an author whose credential is
+ * already `active` returns that row unchanged.
+ */
+export async function issueAuthorCredential(
+  input: IssueAuthorCredentialInput
+): Promise<AuthorCredential> {
+  const supabase = createAdminClient();
+  const vcId = `acta-author-${input.authorSlug}`.slice(0, 64);
+  const network = getActaNetwork();
+
+  const authorIdentity = await createAuthorIdentity(input.authorId);
+  const issuerIdentity = await ensureIssuerIdentity(authorIdentity.stellarAddress);
+
+  // Claim the vc_id slot. Ignored on conflict: a prior attempt (or a second
+  // call for the same author) reuses that row instead of duplicating it.
+  await supabase.from('author_credentials').upsert(
+    {
+      author_id: input.authorId,
+      vc_id: vcId,
+      role: input.role,
+      status: 'pending',
+      issuer_did: issuerIdentity.did,
+      subject_did: authorIdentity.did,
+      network,
+    },
+    { onConflict: 'vc_id', ignoreDuplicates: true }
+  );
+
+  const { data: row, error: rowError } = await supabase
+    .from('author_credentials')
+    .select(
+      'id, author_id, vc_id, role, status, issuer_did, subject_did, network, issue_tx_id, revoke_tx_id, issued_at, revoked_at, revocation_reason'
+    )
+    .eq('vc_id', vcId)
+    .single();
+
+  if (rowError) throw rowError;
+  if (row.status === 'active') return mapRow(row);
+
+  try {
+    await ensureVault(authorIdentity.stellarAddress, issuerIdentity.did);
+
+    const client = getActaClient();
+    const signer = blogSigner();
+    const owner = authorIdentity.stellarAddress;
+
+    const vcData = JSON.stringify({
+      '@context': ['https://www.w3.org/ns/credentials/v2'],
+      type: ['VerifiableCredential', 'ActaAuthorCredential'],
+      credentialSubject: {
+        id: authorIdentity.did,
+        name: input.name,
+        role: input.role,
+        publication: 'ACTA News',
+        profile: `${siteConfig.url}/authors/${input.authorSlug}`,
+      },
+    });
+
+    const prepared = await client.vcIssue({
+      owner,
+      vcId,
+      vcData,
+      issuer: owner,
+      issuerDid: issuerIdentity.did,
+      sourcePublicKey: owner,
+    });
+
+    if (!isTxPrepareResponse(prepared)) {
+      throw new Error('Unexpected ACTA response: expected a prepare response from vcIssue.');
+    }
+
+    const signedXdr = await signer(prepared.xdr, { networkPassphrase: prepared.network });
+    const submitted = await client.vcIssue({ signedXdr });
+
+    if (!isTxSubmitResponse(submitted)) {
+      throw new Error('Unexpected ACTA response: expected a submit response from vcIssue.');
+    }
+
+    const { data: updated, error: updateError } = await supabase
+      .from('author_credentials')
+      .update({
+        status: 'active',
+        issue_tx_id: submitted.tx_id,
+        issued_at: new Date().toISOString(),
+      })
+      .eq('id', row.id)
+      .select(
+        'id, author_id, vc_id, role, status, issuer_did, subject_did, network, issue_tx_id, revoke_tx_id, issued_at, revoked_at, revocation_reason'
+      )
+      .single();
+
+    if (updateError) throw updateError;
+    return mapRow(updated);
+  } catch (err) {
+    await supabase.from('author_credentials').update({ status: 'failed' }).eq('id', row.id);
+    throw toActaApiError(err);
+  }
+}
+
+/** Revokes an author's credential. The reason is shown in admin only. */
+export async function revokeAuthorCredential(
+  vcId: string,
+  reason: string
+): Promise<AuthorCredential> {
+  const supabase = createAdminClient();
+
+  const { data: row, error: rowError } = await supabase
+    .from('author_credentials')
+    .select(
+      'id, author_id, vc_id, role, status, issuer_did, subject_did, network, issue_tx_id, revoke_tx_id, issued_at, revoked_at, revocation_reason'
+    )
+    .eq('vc_id', vcId)
+    .single();
+
+  if (rowError) throw rowError;
+
+  const authorIdentity = await createAuthorIdentity(row.author_id);
+  const client = getActaClient();
+  const signer = blogSigner();
+  const owner = authorIdentity.stellarAddress;
+
+  const prepared = await client.revokeCredentialViaApi({ owner, vcId, sourcePublicKey: owner });
+
+  if (!isTxPrepareResponse(prepared)) {
+    throw new Error('Unexpected ACTA response: expected a prepare response from revoke.');
+  }
+
+  const signedXdr = await signer(prepared.xdr, { networkPassphrase: prepared.network });
+  const submitted = await client.revokeCredentialViaApi({ signedXdr });
+
+  if (!isTxSubmitResponse(submitted)) {
+    throw new Error('Unexpected ACTA response: expected a submit response from revoke.');
+  }
+
+  const { data: updated, error: updateError } = await supabase
+    .from('author_credentials')
+    .update({
+      status: 'revoked',
+      revoke_tx_id: submitted.tx_id,
+      revoked_at: new Date().toISOString(),
+      revocation_reason: reason,
+    })
+    .eq('id', row.id)
+    .select(
+      'id, author_id, vc_id, role, status, issuer_did, subject_did, network, issue_tx_id, revoke_tx_id, issued_at, revoked_at, revocation_reason'
+    )
+    .single();
+
+  if (updateError) throw updateError;
+  return mapRow(updated);
+}
+
+/**
+ * Verifies a credential against the Vault contract, re-checking status
+ * on-chain every call (never cached).
+ */
+export async function verifyAuthorCredential(vcId: string): Promise<CredentialVerification> {
+  const supabase = createAdminClient();
+  const checkedAt = new Date().toISOString();
+
+  const { data: row, error } = await supabase
+    .from('author_credentials')
+    .select('author_id, issuer_did, subject_did')
+    .eq('vc_id', vcId)
+    .maybeSingle();
+
+  if (error) throw error;
+  if (!row) return { status: 'invalid', checkedAt, issuedByActaNews: false };
+
+  // Read-only lookup: `verifyAuthorCredential` is reachable from the public
+  // `/verify/[vcId]` page, so it must never register a DID or write on-chain.
+  const authorIdentity = await getAuthorIdentity(row.author_id);
+  if (!authorIdentity) {
+    return {
+      status: 'invalid',
+      checkedAt,
+      issuerDid: row.issuer_did,
+      subjectDid: row.subject_did,
+      issuedByActaNews: false,
+    };
+  }
+
+  try {
+    const client = getActaClient();
+    const result = await client.vaultVerify({ owner: authorIdentity.stellarAddress, vcId });
+    const issuerIdentity = await getActaClient().getIssuerIdentity(authorIdentity.stellarAddress);
+
+    return {
+      status: result.status,
+      since: result.since,
+      checkedAt,
+      issuerDid: row.issuer_did,
+      subjectDid: row.subject_did,
+      issuedByActaNews: Boolean(issuerIdentity && issuerIdentity.did === row.issuer_did),
+    };
+  } catch (err) {
+    const normalized = toActaApiError(err);
+    if (normalized.status === 404) {
+      return {
+        status: 'invalid',
+        checkedAt,
+        issuerDid: row.issuer_did,
+        subjectDid: row.subject_did,
+        issuedByActaNews: false,
+      };
+    }
+    throw normalized;
+  }
+}

--- a/src/lib/acta/errors.ts
+++ b/src/lib/acta/errors.ts
@@ -1,0 +1,15 @@
+import 'server-only';
+
+import { ActaApiError, normalizeError } from '@acta-team/credentials';
+
+/** ACTA's own code for "the vault already exists" (safe to treat as success). */
+const VAULT_ALREADY_EXISTS_CODE = 'vault_already_exists';
+
+export function isVaultAlreadyExistsError(err: unknown): boolean {
+  const normalized = toActaApiError(err);
+  return normalized.status === 409 || normalized.code === VAULT_ALREADY_EXISTS_CODE;
+}
+
+export function toActaApiError(err: unknown): ActaApiError {
+  return err instanceof ActaApiError ? err : normalizeError(err);
+}

--- a/src/lib/acta/identity-storage.ts
+++ b/src/lib/acta/identity-storage.ts
@@ -1,0 +1,53 @@
+import 'server-only';
+
+import type { IssuerIdentity, IssuerIdentityStorage } from '@acta-team/credentials';
+import { createAdminClient } from '@/lib/supabase/admin';
+import type { Json } from '@/lib/supabase';
+import type { ActaNetwork } from '@/@types/credential';
+
+/** Single-row guard: the blog only ever has one issuer identity. */
+const ROW_ID = 'default';
+
+/**
+ * Persists the ACTA issuer identity in `acta_issuer_identity`.
+ *
+ * Without this, the SDK's default Node storage is in-memory and mints a
+ * brand new `did:stellar` issuer on every server restart — see
+ * `EphemeralIssuerStorageError` in `@acta-team/credentials`. This backend is
+ * durable, so it is never selected as an "ephemeral" store.
+ */
+export class SupabaseIssuerIdentityStorage implements IssuerIdentityStorage {
+  readonly isEphemeral = false;
+
+  async get(controller: string, network: 'mainnet' | 'testnet'): Promise<IssuerIdentity | null> {
+    const supabase = createAdminClient();
+    const { data, error } = await supabase
+      .from('acta_issuer_identity')
+      .select('controller, did, payload, network')
+      .eq('id', ROW_ID)
+      .maybeSingle();
+
+    if (error) throw error;
+    if (!data) return null;
+    if (data.controller !== controller || data.network !== network) return null;
+
+    return data.payload as unknown as IssuerIdentity;
+  }
+
+  async set(identity: IssuerIdentity, network: ActaNetwork): Promise<void> {
+    const supabase = createAdminClient();
+    const { error } = await supabase.from('acta_issuer_identity').upsert(
+      {
+        id: ROW_ID,
+        controller: identity.controller,
+        did: identity.did,
+        payload: identity as unknown as Json,
+        network,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'id' }
+    );
+
+    if (error) throw error;
+  }
+}

--- a/src/lib/acta/identity.ts
+++ b/src/lib/acta/identity.ts
@@ -1,0 +1,91 @@
+import 'server-only';
+
+import { Keypair } from '@stellar/stellar-sdk';
+import { IssuerIdentityProvider, InMemoryIssuerIdentityStorage } from '@acta-team/credentials';
+import { createAdminClient } from '@/lib/supabase/admin';
+import { STELLAR_BLOG_SECRET_KEY } from '@/lib/stellar/config';
+import type { AuthorIdentity } from '@/@types/credential';
+import { createServerSigner } from './signer';
+import { getActaNetwork } from './client';
+
+type AuthorIdentityRow = {
+  author_id: string;
+  did: string;
+  stellar_address: string;
+  vault_contract_id: string | null;
+  network: 'testnet' | 'mainnet';
+};
+
+function mapRow(row: AuthorIdentityRow): AuthorIdentity {
+  return {
+    authorId: row.author_id,
+    did: row.did,
+    stellarAddress: row.stellar_address,
+    vaultContractId: row.vault_contract_id ?? undefined,
+    network: row.network,
+  };
+}
+
+/** The persisted `did:stellar` identity for an author, or `null` if none exists yet. */
+export async function getAuthorIdentity(authorId: string): Promise<AuthorIdentity | null> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from('author_identities')
+    .select('author_id, did, stellar_address, vault_contract_id, network')
+    .eq('author_id', authorId)
+    .maybeSingle();
+
+  if (error) throw error;
+  return data ? mapRow(data) : null;
+}
+
+/**
+ * Registers a real `did:stellar` identity for an author. Idempotent: an
+ * existing identity is returned as-is rather than re-registered.
+ *
+ * Authors have no wallet of their own — self-service onboarding with a
+ * browser wallet is explicitly out of scope for issue #42 — so the blog's own
+ * Stellar account is the on-chain controller for every author DID, exactly as
+ * it already is for article attestations (`STELLAR_BLOG_SECRET_KEY`). What
+ * makes each author's identity distinct is the DID itself: registering with
+ * fresh, never-persisted storage forces the SDK to mint a brand new
+ * `did:stellar` on-chain every call, even though the controller account is
+ * shared. The generated assertion/authentication keys are never written to
+ * our database — only the resulting DID is durable — which is fine because
+ * every later write for this author (vault creation, credential issuance) is
+ * signed by the blog's own key, not the author's.
+ */
+export async function createAuthorIdentity(authorId: string): Promise<AuthorIdentity> {
+  const existing = await getAuthorIdentity(authorId);
+  if (existing) return existing;
+
+  if (!STELLAR_BLOG_SECRET_KEY) throw new Error('Missing STELLAR_BLOG_SECRET_KEY');
+
+  const network = getActaNetwork();
+  const controller = Keypair.fromSecret(STELLAR_BLOG_SECRET_KEY).publicKey();
+
+  const provider = new IssuerIdentityProvider({
+    network,
+    storage: new InMemoryIssuerIdentityStorage(),
+  });
+
+  const identity = await provider.getOrCreate({
+    controller,
+    signTransaction: createServerSigner(STELLAR_BLOG_SECRET_KEY),
+  });
+
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from('author_identities')
+    .insert({
+      author_id: authorId,
+      did: identity.did,
+      stellar_address: controller,
+      network,
+    })
+    .select('author_id, did, stellar_address, vault_contract_id, network')
+    .single();
+
+  if (error) throw error;
+  return mapRow(data);
+}

--- a/src/lib/acta/index.ts
+++ b/src/lib/acta/index.ts
@@ -1,0 +1,11 @@
+export { getActaClient, getActaNetwork } from './client';
+export { createServerSigner } from './signer';
+export { SupabaseIssuerIdentityStorage } from './identity-storage';
+export { createAuthorIdentity, getAuthorIdentity } from './identity';
+export {
+  issueAuthorCredential,
+  revokeAuthorCredential,
+  verifyAuthorCredential,
+  type IssueAuthorCredentialInput,
+} from './credentials';
+export { isVaultAlreadyExistsError, toActaApiError } from './errors';

--- a/src/lib/acta/signer.ts
+++ b/src/lib/acta/signer.ts
@@ -1,0 +1,27 @@
+import 'server-only';
+
+import { Keypair, TransactionBuilder } from '@stellar/stellar-sdk';
+import type { Signer } from '@acta-team/credentials';
+
+/**
+ * Server side signer for ACTA prepare/submit flows.
+ *
+ * ACTA is non custodial: every write returns an unsigned XDR that must be
+ * signed locally. On the server this signs with the blog keypair
+ * (`STELLAR_BLOG_SECRET_KEY`), the same key `src/lib/stellar/attestation.ts`
+ * already uses for article attestations.
+ *
+ * The secret never leaves the server and is never logged. Any operation that
+ * needs an author's own signature instead of the blog's must be routed
+ * through the browser, not through this function — out of scope for now (see
+ * issue #42: "Author self service onboarding with a browser wallet").
+ */
+export function createServerSigner(secret: string): Signer {
+  const keypair = Keypair.fromSecret(secret);
+
+  return async (xdr, options) => {
+    const tx = TransactionBuilder.fromXDR(xdr, options.networkPassphrase);
+    tx.sign(keypair);
+    return tx.toXDR();
+  };
+}

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -599,6 +599,7 @@ export interface Database {
           network: 'testnet' | 'mainnet';
           status: 'pending' | 'confirmed' | 'failed';
           previous_attestation_id: string | null;
+          author_credential_id: string | null;
           created_at: string;
         };
         Insert: {
@@ -611,6 +612,7 @@ export interface Database {
           network: 'testnet' | 'mainnet';
           status: 'pending' | 'confirmed' | 'failed';
           previous_attestation_id?: string | null;
+          author_credential_id?: string | null;
           created_at?: string;
         };
         Update: {
@@ -623,9 +625,17 @@ export interface Database {
           network?: 'testnet' | 'mainnet';
           status?: 'pending' | 'confirmed' | 'failed';
           previous_attestation_id?: string | null;
+          author_credential_id?: string | null;
           created_at?: string;
         };
-        Relationships: [];
+        Relationships: [
+          {
+            foreignKeyName: 'article_attestations_author_credential_id_fkey';
+            columns: ['author_credential_id'];
+            referencedRelation: 'author_credentials';
+            referencedColumns: ['id'];
+          },
+        ];
       };
 
       ecosystem_snapshots: {
@@ -711,6 +721,102 @@ export interface Database {
           },
         ];
       };
+      acta_issuer_identity: {
+        Row: {
+          id: string;
+          controller: string;
+          did: string;
+          payload: Json;
+          network: 'testnet' | 'mainnet';
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          controller: string;
+          did: string;
+          payload: Json;
+          network: 'testnet' | 'mainnet';
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: Partial<Database['public']['Tables']['acta_issuer_identity']['Insert']>;
+        Relationships: [];
+      };
+      author_identities: {
+        Row: {
+          author_id: string;
+          did: string;
+          stellar_address: string;
+          vault_contract_id: string | null;
+          network: 'testnet' | 'mainnet';
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          author_id: string;
+          did: string;
+          stellar_address: string;
+          vault_contract_id?: string | null;
+          network: 'testnet' | 'mainnet';
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: Partial<Database['public']['Tables']['author_identities']['Insert']>;
+        Relationships: [
+          {
+            foreignKeyName: 'author_identities_author_id_fkey';
+            columns: ['author_id'];
+            referencedRelation: 'authors';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      author_credentials: {
+        Row: {
+          id: string;
+          author_id: string;
+          vc_id: string;
+          role: string;
+          status: Database['public']['Enums']['author_credential_status'];
+          issuer_did: string;
+          subject_did: string;
+          network: 'testnet' | 'mainnet';
+          issue_tx_id: string | null;
+          revoke_tx_id: string | null;
+          issued_at: string | null;
+          revoked_at: string | null;
+          revocation_reason: string | null;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          author_id: string;
+          vc_id: string;
+          role: string;
+          status?: Database['public']['Enums']['author_credential_status'];
+          issuer_did: string;
+          subject_did: string;
+          network: 'testnet' | 'mainnet';
+          issue_tx_id?: string | null;
+          revoke_tx_id?: string | null;
+          issued_at?: string | null;
+          revoked_at?: string | null;
+          revocation_reason?: string | null;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: Partial<Database['public']['Tables']['author_credentials']['Insert']>;
+        Relationships: [
+          {
+            foreignKeyName: 'author_credentials_author_id_fkey';
+            columns: ['author_id'];
+            referencedRelation: 'authors';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
     };
     Views: Record<string, never>;
     Functions: {
@@ -756,6 +862,7 @@ export interface Database {
       editorial_role: 'owner' | 'editor' | 'author' | 'contributor';
       review_state: 'requested' | 'approved' | 'changes_requested';
       content_locale: 'en' | 'es';
+      author_credential_status: 'pending' | 'active' | 'revoked' | 'failed';
     };
     CompositeTypes: Record<string, never>;
   };

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -114,6 +114,17 @@ export async function proxy(request: NextRequest) {
     if (pathname.startsWith('/admin/team') && adminUser.role !== 'owner') {
       return NextResponse.redirect(new URL('/admin', request.url));
     }
+
+    // Author identity/credential issuance is owner/editor-only, same as
+    // publishing. The page re-checks with `requireRole` and RLS refuses the
+    // write regardless.
+    if (
+      pathname.startsWith('/admin/authors') &&
+      adminUser.role !== 'owner' &&
+      adminUser.role !== 'editor'
+    ) {
+      return NextResponse.redirect(new URL('/admin', request.url));
+    }
   }
 
   return response;

--- a/src/test/server-only-stub.ts
+++ b/src/test/server-only-stub.ts
@@ -1,0 +1,7 @@
+// Vitest stand-in for Next.js's `server-only` marker package.
+// Next.js aliases the real package to a no-op at build time (see
+// `node_modules/next/dist/compiled/server-only`); it is never installed as a
+// real dependency, so it cannot resolve under plain Node. This mirrors that
+// aliasing for `vitest.config.ts` so server-only modules stay importable in
+// tests without weakening the guard in the actual Next.js build.
+export {};

--- a/supabase/migrations/0008_author_identities.sql
+++ b/supabase/migrations/0008_author_identities.sql
@@ -1,0 +1,117 @@
+-- =============================================================================
+-- ACTA News: verifiable author identity (did:stellar + ACTA credentials)
+--
+-- What this migration adds:
+--   * `acta_issuer_identity` — the blog's own issuer DID, persisted so the
+--     `@acta-team/credentials` SDK never mints a new one on server restart.
+--     Service-role only: no RLS policy grants any access to it at all.
+--   * `author_identities` — one `did:stellar` per author.
+--   * `author_credentials` — the "ACTA Author" verifiable credentials issued
+--     into an author's vault, one active credential per author (see the
+--     cost-model note in issue #42: a credential per article is out of scope).
+--   * `article_attestations.author_credential_id`, linking each free
+--     `manageData` article attestation to the author credential that was
+--     active when the article was attested.
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Credential status enum
+-- ---------------------------------------------------------------------------
+do $$ begin
+  create type public.author_credential_status as enum ('pending', 'active', 'revoked', 'failed');
+exception when duplicate_object then null; end $$;
+
+-- ---------------------------------------------------------------------------
+-- 2. acta_issuer_identity (service role only)
+-- ---------------------------------------------------------------------------
+create table if not exists public.acta_issuer_identity (
+  id text primary key default 'default',
+  controller text not null,
+  did text not null,
+  payload jsonb not null,
+  network text not null check (network in ('testnet', 'mainnet')),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.acta_issuer_identity enable row level security;
+
+-- No policies at all: only the service role (which bypasses RLS) may touch
+-- this table. Anonymous and authenticated roles get nothing, on purpose.
+
+-- ---------------------------------------------------------------------------
+-- 3. author_identities
+-- ---------------------------------------------------------------------------
+create table if not exists public.author_identities (
+  author_id uuid primary key references public.authors (id) on delete cascade,
+  did text not null unique,
+  stellar_address text not null,
+  vault_contract_id text,
+  network text not null check (network in ('testnet', 'mainnet')),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.author_identities enable row level security;
+
+drop policy if exists "author identities are readable by everyone" on public.author_identities;
+drop policy if exists "admins can write author identities" on public.author_identities;
+
+create policy "author identities are readable by everyone"
+  on public.author_identities
+  for select
+  using (true);
+
+create policy "admins can write author identities"
+  on public.author_identities
+  for all
+  to authenticated
+  using (public.is_admin())
+  with check (public.is_admin());
+
+-- ---------------------------------------------------------------------------
+-- 4. author_credentials
+-- ---------------------------------------------------------------------------
+create table if not exists public.author_credentials (
+  id uuid primary key default gen_random_uuid(),
+  author_id uuid not null references public.authors (id) on delete cascade,
+  vc_id text not null unique check (char_length(vc_id) <= 64),
+  role text not null,
+  status public.author_credential_status not null default 'pending',
+  issuer_did text not null,
+  subject_did text not null,
+  network text not null check (network in ('testnet', 'mainnet')),
+  issue_tx_id text,
+  revoke_tx_id text,
+  issued_at timestamptz,
+  revoked_at timestamptz,
+  revocation_reason text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists author_credentials_author_id_idx
+  on public.author_credentials (author_id);
+
+alter table public.author_credentials enable row level security;
+
+drop policy if exists "author credentials are readable by everyone" on public.author_credentials;
+drop policy if exists "admins can write author credentials" on public.author_credentials;
+
+create policy "author credentials are readable by everyone"
+  on public.author_credentials
+  for select
+  using (true);
+
+create policy "admins can write author credentials"
+  on public.author_credentials
+  for all
+  to authenticated
+  using (public.is_admin())
+  with check (public.is_admin());
+
+-- ---------------------------------------------------------------------------
+-- 5. article_attestations: link to the author credential active at publish time
+-- ---------------------------------------------------------------------------
+alter table public.article_attestations
+  add column if not exists author_credential_id uuid references public.author_credentials (id);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,13 @@ export default defineConfig({
     include: ['src/**/*.test.ts'],
   },
   resolve: {
-    // Mirror the `@/*` → `./src/*` alias from tsconfig.json.
-    alias: { '@': fileURLToPath(new URL('./src', import.meta.url)) },
+    alias: {
+      // Mirror the `@/*` → `./src/*` alias from tsconfig.json.
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+      // Next.js aliases `server-only` to a no-op at build time; it is not a
+      // real dependency, so it cannot resolve under plain Node. See
+      // `src/test/server-only-stub.ts`.
+      'server-only': fileURLToPath(new URL('./src/test/server-only-stub.ts', import.meta.url)),
+    },
   },
 });


### PR DESCRIPTION
# 🚀 ACTA Pull Request

- [x] Closes #42
- [x] Added tests (if necessary)
- [x] Run tests
- [x] Run formatting
- [ ] Evidence attached
- [x] Commented the code

---

### 📌 Type of Change

- [ ] Documentation (updates to README, docs, or comments)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

---

## 📝 Changes description

Gives every author a real `did:stellar` identity and an **ACTA Author** credential issued through `@acta-team/credentials`, then surfaces that credential to readers, per issue #42.

- **Migration** `0008_author_identities.sql` (issue suggested `0005`, but the branch had already moved to `0007`): `acta_issuer_identity` (service-role only, no RLS policies at all), `author_identities`, `author_credentials`, plus `article_attestations.author_credential_id`. RLS: public read on the two author-facing tables, admin-only write.
- **`src/lib/acta/`**: `client.ts` (singleton `ActaClient`), `signer.ts` (server-side XDR signer using the existing `STELLAR_BLOG_SECRET_KEY`), `identity-storage.ts` (durable `IssuerIdentityStorage` backed by `acta_issuer_identity`), `identity.ts` (author DID registration), `credentials.ts` (issue/revoke/verify, idempotent on `vc_id`, `vault_already_exists` treated as success), `errors.ts`, tests mocking the SDK client.
- **Public UI**: `VerifiedAuthorBadge` (wired into `AuthorProfile`, `AuthorCard`, `NewsCard`, `NewsDetail`), new `src/components/modules/credentials/` module, `/verify/[vcId]` route (`revalidate = 0`), an "Author" row on `AttestationPanel`.
- **Admin UI**: new `/admin/authors` (owner/editor only, gated in `proxy.ts` and `requireRole`) with `AuthorIdentityPanel` driving three server actions: create identity → issue credential → revoke credential (reason required). Every on-chain call is fire-and-forget so the request never blocks on chain latency.
- `.env.example`: `ACTA_API_KEY`, `ACTA_NETWORK`, `NEXT_PUBLIC_ACTA_NETWORK`.

### ⚠️ Design decision worth flagging for review

Authors have no wallet of their own (self-service onboarding is explicitly out of scope for this issue), and the schema intentionally stores no author secret key. So every author DID — and the single shared credential vault — is registered with **the blog's own Stellar account as the on-chain controller/owner**, exactly like article attestations already are. What makes each author's identity distinct is the DID itself (a fresh registration mints a new `did:stellar` every time) and the credential's `credentialSubject.id`. This is why `vault_already_exists` (expected from the second author onward, since the vault is shared) is treated as success rather than an edge case. Happy to revisit if the ACTA team intended a different custody model.

## 📸 Evidence

No Loom/Cap video: I don't have a live `ACTA_API_KEY` / funded Stellar testnet account to exercise real on-chain issuance, so on-chain behavior is verified through unit tests with the SDK client mocked (`src/lib/acta/__tests__/credentials.test.ts`, 9 tests covering idempotency, `vault_already_exists`, failed submits, and all three `verifyAuthorCredential` outcomes). Verified instead:
- `npm run lint`, `npm run test`, `npx tsc --noEmit`, and `npm run build` all pass.
- Migration SQL reviewed for syntax/convention against the existing migrations (not run against a live `db:reset`, no local Docker instance available in this environment).

## ⏰ Time spent breakdown

Research (existing codebase conventions + `@acta-team/credentials` SDK types) ~40%, implementation ~45%, verification (tests/lint/build) ~15%.

## 🌌 Comments

Assumptions made, called out for reviewer judgment:
- Shared-vault/shared-controller custody model described above.
- `/verify/[vcId]` 404s both for an unknown `vc_id` and for a verification-service outage, rather than distinguishing the two.
- Owner/editor gating on `/admin/authors`, matching the existing `canPublish` capability rather than adding a new one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added verifiable author identities and credentials, including issuance, revocation, and status tracking.
  * Added an Authors area for authorized administrators to manage identities and credentials.
  * Added credential verification pages with issuer, subject, status, and timestamp details.
  * Added verification badges to author profiles, news cards, and articles.
  * Article attestations now reference the author credential used at publication.
* **Documentation**
  * Added configuration guidance for credential services and network selection.
* **Localization**
  * Added English and Spanish translations for credential statuses and verification details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->